### PR TITLE
heliumos#680 bugfix:个人主页收起群聊后，其他社区默认分组下的频道不展示（优化roomlist layout存储机制）

### DIFF
--- a/src/matrix-react-sdk/src/components/views/rooms/RoomList.tsx
+++ b/src/matrix-react-sdk/src/components/views/rooms/RoomList.tsx
@@ -692,7 +692,7 @@ export default class RoomList extends React.PureComponent<IProps, IState> {
             // of keeping it in the DOM and hiding it when it is not required
             return (
                 <RoomSublist
-                    key={`sublist-${orderedTagId}`}
+                    key={`sublist-${this.props.activeSpace}-${orderedTagId}`}
                     index={this.state.spaceTagIds.indexOf(orderedTagId)}
                     tagId={orderedTagId}
                     forRooms={true}

--- a/src/matrix-react-sdk/src/components/views/rooms/RoomSublist.tsx
+++ b/src/matrix-react-sdk/src/components/views/rooms/RoomSublist.tsx
@@ -127,7 +127,7 @@ export default class RoomSublist extends React.Component<IProps, IState> {
         // when this setting is toggled it restarts the app so it's safe to not watch this.
         this.slidingSyncMode = SettingsStore.getValue("feature_sliding_sync");
 
-        this.layout = RoomListLayoutStore.instance.getLayoutFor(this.props.tagId);
+        this.layout = RoomListLayoutStore.instance.getLayoutFor(SpaceStore.instance.activeSpace, this.props.tagId);
         this.heightAtStart = 0;
         this.notificationState = RoomNotificationStateStore.instance.getListState(this.props.tagId);
         this.state = {

--- a/src/matrix-react-sdk/src/stores/room-list/Interface.ts
+++ b/src/matrix-react-sdk/src/stores/room-list/Interface.ts
@@ -17,8 +17,9 @@ limitations under the License.
 import type { Room } from "matrix-js-sdk/src/models/room";
 import type { EventEmitter } from "events";
 import { ITagMap, ListAlgorithm, SortAlgorithm } from "./algorithms/models";
-import { RoomUpdateCause, TagID } from "./models";
+import { RoomUpdateCause, Tag, TagID } from "./models";
 import { IFilterCondition } from "./filters/IFilterCondition";
+import { SpaceKey } from "matrix-react-sdk/src/stores/spaces";
 
 export enum RoomListStoreEvent {
     // The event/channel which is called when the room lists have been changed.
@@ -81,7 +82,7 @@ export interface RoomListStore extends EventEmitter {
      * @param params.trigger Set to false to prevent a list update from being sent. Should only
      * be used if the calling code will manually trigger the update.
      */
-    regenerateAllLists(params: { trigger: boolean }): void;
+    regenerateAllLists(params: { trigger: boolean; space?: SpaceKey; spaceTags?: Tag[] }): void;
 
     /**
      * Adds a filter condition to the room list store. Filters may be applied async,

--- a/src/matrix-react-sdk/src/stores/room-list/ListLayout.ts
+++ b/src/matrix-react-sdk/src/stores/room-list/ListLayout.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import { TagID } from "./models";
+import { SpaceKey } from "matrix-react-sdk/src/stores/spaces";
 
 const TILE_HEIGHT_PX = 44;
 
@@ -29,7 +30,10 @@ export class ListLayout {
     private _previews = false;
     private _collapsed = false;
 
-    public constructor(public readonly tagId: TagID) {
+    public constructor(
+        public readonly spaceId: SpaceKey,
+        public readonly tagId: TagID,
+    ) {
         const serialized = localStorage.getItem(this.key);
         if (serialized) {
             // We don't use the setters as they cause writes.
@@ -63,7 +67,7 @@ export class ListLayout {
     }
 
     private get key(): string {
-        return `mx_sublist_layout_${this.tagId}_boxed`;
+        return `mx_sublist_layout${this.spaceId ? `_${this.spaceId}` : ""}_${this.tagId}_boxed`;
     }
 
     public get visibleTiles(): number {

--- a/src/matrix-react-sdk/src/stores/room-list/RoomListStore.ts
+++ b/src/matrix-react-sdk/src/stores/room-list/RoomListStore.ts
@@ -553,7 +553,7 @@ export class RoomListStoreClass extends AsyncStoreWithClient<IState> implements 
      * @param trigger Set to false to prevent a list update from being sent. Should only
      * be used if the calling code will manually trigger the update.
      */
-    public regenerateAllLists({ trigger = true, spaceTags = [] }): void {
+    public regenerateAllLists({ trigger = true, space = SpaceStore.instance.activeSpace, spaceTags = [] }) {
         logger.warn("Regenerating all room lists");
 
         const rooms = this.getPlausibleRooms();
@@ -566,7 +566,7 @@ export class RoomListStoreClass extends AsyncStoreWithClient<IState> implements 
             sorts[tagId] = this.calculateTagSorting(tagId);
             orders[tagId] = this.calculateListOrder(tagId);
 
-            RoomListLayoutStore.instance.ensureLayoutExists(tagId);
+            RoomListLayoutStore.instance.ensureLayoutExists(space, tagId);
         }
 
         this.algorithm.populateTags(sorts, orders);

--- a/src/matrix-react-sdk/src/stores/room-list/SpaceWatcher.ts
+++ b/src/matrix-react-sdk/src/stores/room-list/SpaceWatcher.ts
@@ -68,6 +68,7 @@ export class SpaceWatcher {
 
     private onSpaceTagsUpdate = (spaceTags) => {
         this.store.regenerateAllLists({
+            space: this.activeSpace,
             spaceTags,
             trigger: true,
         });


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-web/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

For PRs which *only* affect the desktop version, please use:

Notes: none
element-desktop notes: Add super cool feature
-->
