### PR TITLE
heliumos#660 权限相关处理

### DIFF
--- a/src/@types/matrix-js-sdk.d.ts
+++ b/src/@types/matrix-js-sdk.d.ts
@@ -2,6 +2,12 @@ import { RoomType } from "../vector/rewrite-js-sdk/room";
 import { ISendEventResponse } from "matrix-js-sdk/src/@types/requests";
 import { Tag } from "matrix-react-sdk/src/stores/room-list/models";
 
+declare module "matrix-js-sdk/src/@types/partials" {
+    interface IEnableDefaultUserSendMsgEventContent {
+        enable: boolean;
+    }
+}
+
 declare module "matrix-js-sdk/src/client" {
     interface MatrixClient {
         setRoomOnlyTags(roomId: string, tags: Tag[]): Promise<ISendEventResponse>;
@@ -16,7 +22,7 @@ declare module "matrix-js-sdk/src/models/room-state" {
 }
 
 declare module "matrix-js-sdk/src/models/room" {
-    export interface Room {
+    interface Room {
         isAdminLeft(): boolean;
         isPeopleRoom(): boolean;
         getRoomType(): RoomType;

--- a/src/@types/matrix-js-sdk.d.ts
+++ b/src/@types/matrix-js-sdk.d.ts
@@ -6,6 +6,10 @@ declare module "matrix-js-sdk/src/@types/partials" {
     interface IEnableDefaultUserSendMsgEventContent {
         enable: boolean;
     }
+
+    interface IEnableDefaultUserMemberListContent {
+        enable: boolean;
+    }
 }
 
 declare module "matrix-js-sdk/src/client" {
@@ -35,6 +39,7 @@ declare module "matrix-js-sdk/src/models/room" {
         isRestrictedRoom(): boolean;
         isPrivateRoom(): boolean;
         canRemoveUser(userId: string): boolean;
+        displayMemberList(userId: string): boolean;
         canOperateTag(userId: string): boolean;
     }
 }

--- a/src/@types/matrix-js-sdk.d.ts
+++ b/src/@types/matrix-js-sdk.d.ts
@@ -3,11 +3,11 @@ import { ISendEventResponse } from "matrix-js-sdk/src/@types/requests";
 import { Tag } from "matrix-react-sdk/src/stores/room-list/models";
 
 declare module "matrix-js-sdk/src/@types/partials" {
-    interface IEnableDefaultUserSendMsgEventContent {
+    interface IEnableSendMsgEventContent {
         enable: boolean;
     }
 
-    interface IEnableDefaultUserMemberListContent {
+    interface IEnableMemberListContent {
         enable: boolean;
     }
 }

--- a/src/matrix-react-sdk/res/css/structures/_SpaceHierarchy.pcss
+++ b/src/matrix-react-sdk/res/css/structures/_SpaceHierarchy.pcss
@@ -71,6 +71,7 @@ limitations under the License.
     }
 
     .mx_SpaceHierarchy_noResults {
+        padding: 40px 20px;
         text-align: center;
 
         > div {

--- a/src/matrix-react-sdk/res/css/views/elements/_ImageView.pcss
+++ b/src/matrix-react-sdk/res/css/views/elements/_ImageView.pcss
@@ -66,7 +66,7 @@ $button-gap: 24px;
     display: flex;
     flex-direction: row;
     align-items: center;
-    color: $lightbox-fg-color;
+    color: $text-secondary-color1;
     flex-grow: 1;
     flex-basis: 0;
 }
@@ -82,7 +82,7 @@ $button-gap: 24px;
 }
 
 .mx_ImageView_title {
-    color: $lightbox-fg-color;
+    color: $text-secondary-color1;
     font-size: $font-12px;
     flex-grow: 1;
     flex-basis: 0;

--- a/src/matrix-react-sdk/res/css/views/rooms/_RoomSublist.pcss
+++ b/src/matrix-react-sdk/res/css/views/rooms/_RoomSublist.pcss
@@ -182,14 +182,6 @@ limitations under the License.
         }
     }
 
-    /* In the general case, we reserve space for each sublist header to prevent */
-    /* scroll jumps when they become sticky. However, that leaves a gap when */
-    /* scrolled to the top above the first sublist (whose header can only ever */
-    /* stick to top), so we make sure to exclude the first visible sublist. */
-    &:not(.mx_RoomSublist_hidden) ~ .mx_RoomSublist .mx_RoomSublist_stickableContainer {
-        height: 24px;
-    }
-
     .mx_RoomSublist_resizeBox {
         position: relative;
 

--- a/src/matrix-react-sdk/res/css/views/rooms/_RoomTile.pcss
+++ b/src/matrix-react-sdk/res/css/views/rooms/_RoomTile.pcss
@@ -31,7 +31,6 @@ limitations under the License.
     }
 
     &.mx_RoomTile_selected,
-    &:focus-within,
     &.mx_RoomTile_hasMenuOpen {
         background-color: $background-primary2-secondary-color3;
         .mx_RoomTile_title {

--- a/src/matrix-react-sdk/res/css/views/settings/_JoinRuleSettings.pcss
+++ b/src/matrix-react-sdk/res/css/views/settings/_JoinRuleSettings.pcss
@@ -71,13 +71,12 @@ limitations under the License.
     & + span {
         display: inline-block;
         margin-left: 34px;
-        margin-bottom: 16px;
-        font-size: $font-15px;
+        margin-bottom: 20px;
+        font-size: $font-14px;
         line-height: $font-24px;
-        color: $secondary-content;
-
-        & + .mx_StyledRadioButton {
-            border-top: 1px solid $quinary-content;
+        color: $text-secondary-color2;
+        &:last-of-type {
+            margin-bottom: 0;
         }
     }
 }

--- a/src/matrix-react-sdk/src/Login.ts
+++ b/src/matrix-react-sdk/src/Login.ts
@@ -173,6 +173,7 @@ export default class Login {
                 throw originalLoginError;
             })
             .catch((error) => {
+                console.error("init bugfix loginViaJwt request error", error);
                 logger.log("Login failed", error);
                 throw error;
             });
@@ -181,8 +182,8 @@ export default class Login {
 
 // jwt登录
 export function jwtLoginRequest(client: MatrixClient): Promise<any> {
-    return fetch('/heliumos-chat-api/user/v1/matrices/login', {
-        method: 'POST'
+    return fetch("/heliumos-chat-api/user/v1/matrices/login", {
+        method: "POST",
     })
         .then((response) => response.json())
         .then((res) => {
@@ -218,7 +219,7 @@ export async function sendLoginRequest(
     isUrl: string | undefined,
     loginType: string,
     loginParams: ILoginParams,
-    isOriginalLogin = true
+    isOriginalLogin = true,
 ): Promise<IMatrixClientCreds> {
     const client = createClient({
         baseUrl: hsUrl,

--- a/src/matrix-react-sdk/src/RoomInvite.tsx
+++ b/src/matrix-react-sdk/src/RoomInvite.tsx
@@ -78,7 +78,7 @@ export function showStartChatInviteDialog(initialText = ""): void {
     );
 }
 
-export function showRoomInviteDialog(roomId: string, initialText = ""): void {
+export function showRoomInviteDialog(roomId: string, initialText = "", inviteToSpace: boolean = false): void {
     // This dialog handles the room creation internally - we don't need to worry about it.
     Modal.createDialog(
         InviteDialog,
@@ -86,6 +86,7 @@ export function showRoomInviteDialog(roomId: string, initialText = ""): void {
             kind: InviteKind.Invite,
             initialText,
             roomId,
+            inviteToSpace,
         } as Omit<ComponentProps<typeof InviteDialog>, "onFinished">,
         /*className=*/ "mx_InviteDialog_flexWrapper",
         /*isPriority=*/ false,

--- a/src/matrix-react-sdk/src/RoomInvite.tsx
+++ b/src/matrix-react-sdk/src/RoomInvite.tsx
@@ -121,7 +121,7 @@ export function inviteUsersToRoom(
     return inviteMultipleToRoom(roomId, userIds, sendSharedHistoryKeys, progressCallback)
         .then((result) => {
             const room = MatrixClientPeg.get().getRoom(roomId)!;
-            showAnyInviteErrors(result.states, room, result.inviter);
+            showInviteResult(result.states, room, result.inviter);
         })
         .catch((err) => {
             logger.error(err.stack);

--- a/src/matrix-react-sdk/src/components/structures/MatrixChat.tsx
+++ b/src/matrix-react-sdk/src/components/structures/MatrixChat.tsx
@@ -302,6 +302,8 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
 
         RoomNotificationStateStore.instance.on(UPDATE_STATUS_INDICATOR, this.onUpdateStatusIndicator);
 
+        console.log("init bugfix isSoftLogout", Lifecycle.isSoftLogout());
+
         // Force users to go through the soft logout page if they're soft logged out
         if (Lifecycle.isSoftLogout()) {
             // When the session loads it'll be detected as soft logged out and a dispatch
@@ -331,6 +333,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
                 this.props.defaultDeviceDisplayName,
                 this.getFragmentAfterLogin(),
             ).then(async (loggedIn): Promise<boolean | void> => {
+                console.log("init bugfix loggedIn", loggedIn);
                 if (this.props.realQueryParams?.loginToken) {
                     // remove the loginToken from the URL regardless
                     this.props.onTokenLoginCompleted();
@@ -351,6 +354,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
                 const firstScreen = this.screenAfterLogin ? this.screenAfterLogin.screen : null;
 
                 const restoreSuccess = await this.loadSession();
+                console.log("init bugfix restoreSuccess", restoreSuccess);
                 if (restoreSuccess) {
                     return true;
                 }
@@ -367,6 +371,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
     }
 
     private async postLoginSetup(): Promise<void> {
+        console.log("---init bugfix enter postLoginSetup");
         const cli = MatrixClientPeg.get();
         const cryptoEnabled = cli.isCryptoEnabled();
         if (!cryptoEnabled) {
@@ -382,6 +387,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
             promisesList.push(
                 (async (): Promise<void> => {
                     crossSigningIsSetUp = await cli.userHasCrossSigningKeys();
+                    console.log("init bugfix crossSigningIsSetUp");
                 })(),
             );
         }
@@ -390,7 +396,11 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
         // than for the login to finish.
         this.setState({ pendingInitialSync: true });
 
+        console.log("init bugfix await promisesList", promisesList);
+
         await Promise.all(promisesList);
+
+        console.log("init bugfix promisesList resolved");
 
         if (!cryptoEnabled) {
             this.setState({ pendingInitialSync: false });
@@ -398,6 +408,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
         }
 
         if (crossSigningIsSetUp) {
+            console.log("nit bugfix postLoginSetup 1 crossSigningIsSetUp");
             // if the user has previously set up cross-signing, verify this device so we can fetch the
             // private keys.
             if (SecurityCustomisations.SHOW_ENCRYPTION_SETUP_UI === false) {
@@ -406,9 +417,11 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
                 this.setStateForNewView({ view: Views.COMPLETE_SECURITY });
             }
         } else if (await cli.doesServerSupportUnstableFeature("org.matrix.e2e_cross_signing")) {
+            console.log("init bugfix postLoginSetup 2");
             // if cross-signing is not yet set up, do so now if possible.
             this.setStateForNewView({ view: Views.E2E_SETUP });
         } else {
+            console.log("init bugfix postLoginSetup 3");
             this.onLoggedIn();
         }
         this.setState({ pendingInitialSync: false });
@@ -514,6 +527,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
     }
 
     private loadSession(): Promise<boolean> {
+        console.log("---init bugfix enter Matrix loadedSession");
         // the extra Promise.resolve() ensures that synchronous exceptions hit the same codepath as
         // asynchronous ones.
         return Promise.resolve()
@@ -527,11 +541,13 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
                 });
             })
             .then((loadedSession) => {
+                console.log("init bugfix loadedSession", loadedSession);
                 if (!loadedSession) {
                     // fall back to showing the welcome screen... unless we have a 3pid invite pending
                     if (ThreepidInviteStore.instance.pickBestInvite()) {
                         dis.dispatch({ action: "start_registration" });
                     } else {
+                        console.log("init bugfix dispatch view_welcome_page");
                         dis.dispatch({ action: "view_welcome_page" });
                     }
                 }
@@ -770,9 +786,11 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
                 break;
             }
             case "view_welcome_page":
+                console.log("init bugfix 订阅到 view_welcome_page");
                 this.viewWelcome();
                 break;
             case Action.ViewHomePage:
+                console.log("init bugfix 订阅到 Action.ViewHomePage");
                 this.viewHome(payload.justRegistered);
                 break;
             case Action.ViewStartChatOrReuse:
@@ -824,6 +842,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
                 Modal.createDialog(DialPadModal, {}, "mx_Dialog_dialPadWrapper");
                 break;
             case Action.OnLoggedIn:
+                console.log("init bugfix 订阅到 Action.OnLoggedIn");
                 this.stores.client = MatrixClientPeg.get();
                 if (
                     // Skip this handling for token login as that always calls onLoggedIn itself
@@ -1034,6 +1053,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
     }
 
     private viewWelcome(): void {
+        console.log("init bugfix enter viewWelcome");
         if (shouldUseLoginForWelcome(SdkConfig.get())) {
             return this.viewLogin();
         }
@@ -1046,6 +1066,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
     }
 
     private viewLogin(otherState?: any): void {
+        console.log("init bugfix enter viewLogin");
         this.setStateForNewView({
             view: Views.LOGIN,
             ...otherState,
@@ -1331,6 +1352,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
      * Called when a new logged in session has started
      */
     private async onLoggedIn(): Promise<void> {
+        console.log("---init bugfix enter onLoggedIn");
         ThemeController.isLogin = false;
         this.themeWatcher.recheck();
         StorageManager.tryPersistStorage();
@@ -1362,6 +1384,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
     }
 
     private async onShowPostLoginScreen(useCase?: UseCase): Promise<void> {
+        console.log("---init bugfix enter onShowPostLoginScreen");
         if (useCase) {
             PosthogAnalytics.instance.setProperty("ftueUseCaseSelection", useCase);
             SettingsStore.setValue("FTUE.useCaseSelection", null, SettingLevel.ACCOUNT, useCase);
@@ -1371,9 +1394,11 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
         // If a specific screen is set to be shown after login, show that above
         // all else, as it probably means the user clicked on something already.
         if (this.screenAfterLogin?.screen) {
+            console.log("---init bugfix onShowPostLoginScreen 1");
             this.showScreen(this.screenAfterLogin.screen, this.screenAfterLogin.params);
             this.screenAfterLogin = undefined;
         } else if (MatrixClientPeg.currentUserIsJustRegistered()) {
+            console.log("---init bugfix onShowPostLoginScreen 2");
             MatrixClientPeg.setJustRegisteredUserId(null);
 
             const snakedConfig = new SnakedObject<IConfigOptions>(this.props.config);
@@ -1398,6 +1423,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
                 dis.dispatch<ViewHomePagePayload>({ action: Action.ViewHomePage, justRegistered: true });
             }
         } else {
+            console.log("---init bugfix onShowPostLoginScreen 3");
             this.showScreenAfterLogin();
         }
 
@@ -1458,18 +1484,23 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
     }
 
     private showScreenAfterLogin(): void {
+        console.log("---init bugfix enter showScreenAfterLogin");
         // If screenAfterLogin is set, use that, then null it so that a second login will
         // result in view_home_page, _user_settings or _room_directory
         if (this.screenAfterLogin && this.screenAfterLogin.screen) {
+            console.log("---init bugfix showScreenAfterLogin 1");
             this.showScreen(this.screenAfterLogin.screen, this.screenAfterLogin.params);
             this.screenAfterLogin = undefined;
         } else if (localStorage && localStorage.getItem("mx_last_room_id")) {
+            console.log("---init bugfix showScreenAfterLogin 2");
             // Before defaulting to directory, show the last viewed room
             this.viewLastRoom();
         } else {
             if (MatrixClientPeg.get().isGuest()) {
+                console.log("---init bugfix showScreenAfterLogin 3");
                 dis.dispatch({ action: "view_welcome_page" });
             } else {
+                console.log("---init bugfix showScreenAfterLogin 4, dispatch Action.ViewHomePage");
                 dis.dispatch({ action: Action.ViewHomePage });
             }
         }
@@ -1778,6 +1809,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
     }
 
     public showScreen(screen: string, params?: { [key: string]: any }): void {
+        console.log("---init bugfix enter showScreen", "screen", screen, "params", params);
         const cli = MatrixClientPeg.get();
         const isLoggedOutOrGuest = !cli || cli.isGuest();
         if (!isLoggedOutOrGuest && AUTH_SCREENS.includes(screen)) {
@@ -2066,10 +2098,12 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
      * this, as they instead jump straight into the app after `attemptTokenLogin`.
      */
     private onUserCompletedLoginFlow = async (credentials: IMatrixClientCreds, password: string): Promise<void> => {
+        console.log("---init bugfix enter onUserCompletedLoginFlow");
         this.stores.accountPasswordStore.setPassword(password);
 
         // Create and start the client
         await Lifecycle.setLoggedIn(credentials);
+        console.log("init bugfix setLoggedIn success");
         await this.postLoginSetup();
 
         PerformanceMonitor.instance.stop(PerformanceEntryNames.LOGIN);

--- a/src/matrix-react-sdk/src/components/structures/SpaceHierarchy.tsx
+++ b/src/matrix-react-sdk/src/components/structures/SpaceHierarchy.tsx
@@ -36,7 +36,7 @@ import { getKeyBindingsManager } from "../../KeyBindingsManager";
 import { getDisplayAliasForAliasSet } from "../../Rooms";
 import SettingsStore from "../../settings/SettingsStore";
 import { ISuggestedRoom, UPDATE_FILTERED_SUGGESTED_ROOMS, UPDATE_SPACE_TAGS } from "matrix-react-sdk/src/stores/spaces";
-import { DefaultTagID } from "matrix-react-sdk/src/stores/room-list/models";
+import { DefaultTagID, TagID } from "matrix-react-sdk/src/stores/room-list/models";
 import SpaceChannelAvatar from "matrix-react-sdk/src/components/views/avatars/SpaceChannelAvatar";
 import { isPrivateRoom } from "../../../../vector/rewrite-js-sdk/room";
 import RoomListStore, { LISTS_UPDATE_EVENT } from "matrix-react-sdk/src/stores/room-list/RoomListStore";
@@ -46,6 +46,12 @@ interface IProps {
     initialText?: string;
     additionalButtons?: ReactNode;
     showRoom(cli: MatrixClient, room: IHierarchyRoom | Room): void;
+}
+
+interface hierarchyItem {
+    tagId: TagID;
+    tagName?: string;
+    children?: Room[] | ISuggestedRoom[];
 }
 
 // 预览已加入的频道
@@ -146,7 +152,7 @@ export const HierarchyLevel: React.FC<IHierarchyLevelProps> = ({ space, query = 
         () => SpaceStore.instance.filteredSuggestedRooms,
     );
 
-    const [hierarchyList, setHierarchyList] = useState([]);
+    const [hierarchyList, setHierarchyList] = useState<hierarchyItem[]>([]);
 
     const [isSearch, setIsSearch] = useState<boolean>(false); // 是否是搜索
 
@@ -259,7 +265,13 @@ export const HierarchyLevel: React.FC<IHierarchyLevelProps> = ({ space, query = 
                                         className="mx_RoomTile"
                                         onClick={() => onViewRoomClick(room)}
                                     >
-                                        <SpaceChannelAvatar isPrivate={isPrivateRoom(room.join_rule)} />
+                                        <SpaceChannelAvatar
+                                            isPrivate={
+                                                room instanceof Room
+                                                    ? room.isPrivateRoom()
+                                                    : isPrivateRoom(room.join_rule)
+                                            }
+                                        />
                                         <div className="mx_RoomTile_titleContainer">
                                             <div className="mx_RoomTile_title" tabIndex={-1}>
                                                 <span className="mx_RoomTile_title" dir="auto">

--- a/src/matrix-react-sdk/src/components/structures/auth/Login.tsx
+++ b/src/matrix-react-sdk/src/components/structures/auth/Login.tsx
@@ -226,8 +226,8 @@ export default class LoginComponent extends React.PureComponent<IProps, IState> 
                     errorText = _t("This homeserver does not support login using email address.");
                 } else if (error.errcode === "M_RESOURCE_LIMIT_EXCEEDED") {
                     const errorTop = messageForResourceLimitError(error.data.limit_type, error.data.admin_contact, {
-                        "monthly_active_user": _td("This homeserver has hit its Monthly Active User limit."),
-                        "hs_blocked": _td("This homeserver has been blocked by its administrator."),
+                        monthly_active_user: _td("This homeserver has hit its Monthly Active User limit."),
+                        hs_blocked: _td("This homeserver has been blocked by its administrator."),
                         "": _td("This homeserver has exceeded one of its resource limits."),
                     });
                     const errorDetail = messageForResourceLimitError(error.data.limit_type, error.data.admin_contact, {
@@ -372,7 +372,9 @@ export default class LoginComponent extends React.PureComponent<IProps, IState> 
     // };
 
     private onLoginViaJwt = (): void => {
+        console.log("init bugfix enter onLoginViaJwt");
         this.loginLogic.loginViaJwt().then(async (data) => {
+            console.log("init bugfix loginViaJwt request success", data);
             this.setState({ serverIsAlive: true });
             this.props.onChangeTokenLogin(true);
             this.props.onLoggedIn(data, "");

--- a/src/matrix-react-sdk/src/components/views/context_menus/RoomGeneralContextMenu.tsx
+++ b/src/matrix-react-sdk/src/components/views/context_menus/RoomGeneralContextMenu.tsx
@@ -113,7 +113,7 @@ export const RoomGeneralContextMenu: React.FC<RoomGeneralContextMenuProps> = ({
 
     // 私密频道特权用户展示邀请成员按钮
     let inviteOption;
-    if (SpaceStore.instance.isSpacePrivilegedUser && room.isPrivateRoom()) {
+    if (SpaceStore.instance.canManageSpacePrivateChannel && room.isPrivateRoom()) {
         inviteOption = <IconizedContextMenuOption onClick={onInvitePeople} label={_t("Invite people")} />;
     }
 

--- a/src/matrix-react-sdk/src/components/views/context_menus/RoomGeneralContextMenu.tsx
+++ b/src/matrix-react-sdk/src/components/views/context_menus/RoomGeneralContextMenu.tsx
@@ -34,6 +34,8 @@ import IconizedContextMenu, {
     IconizedContextMenuOptionList,
 } from "../context_menus/IconizedContextMenu";
 import { ButtonEvent } from "../elements/AccessibleButton";
+import SpaceStore from "matrix-react-sdk/src/stores/spaces/SpaceStore";
+import { showRoomInviteDialog } from "matrix-react-sdk/src/RoomInvite";
 
 export interface RoomGeneralContextMenuProps extends IContextMenuProps {
     room: Room;
@@ -105,10 +107,21 @@ export const RoomGeneralContextMenu: React.FC<RoomGeneralContextMenuProps> = ({
             />
         ) : null;
 
+    const onInvitePeople = () => {
+        showRoomInviteDialog(room.roomId, "", true);
+    };
+
+    // 私密频道特权用户展示邀请成员按钮
+    let inviteOption;
+    if (SpaceStore.instance.isSpacePrivilegedUser && room.isPrivateRoom()) {
+        inviteOption = <IconizedContextMenuOption onClick={onInvitePeople} label={_t("Invite people")} />;
+    }
+
     return (
         <IconizedContextMenu {...props} onFinished={onFinished} className="mx_RoomGeneralContextMenu" compact>
             <IconizedContextMenuOptionList>
                 {/*{markAsReadOption}*/}
+                {inviteOption}
                 {!roomTags.includes(DefaultTagID.Archived) && !isAdminLeft && <>{settingsOption}</>}
             </IconizedContextMenuOptionList>
         </IconizedContextMenu>

--- a/src/matrix-react-sdk/src/components/views/dialogs/CreateChannelDialog.tsx
+++ b/src/matrix-react-sdk/src/components/views/dialogs/CreateChannelDialog.tsx
@@ -18,7 +18,7 @@ limitations under the License.
 import React, { ChangeEvent, createRef } from "react";
 import { Room } from "matrix-js-sdk/src/models/room";
 import { RoomType } from "matrix-js-sdk/src/@types/event";
-import { HistoryVisibility, JoinRule, Preset, Visibility } from "matrix-js-sdk/src/@types/partials";
+import { JoinRule, Preset, Visibility } from "matrix-js-sdk/src/@types/partials";
 
 import SdkConfig from "../../../SdkConfig";
 import withValidation, { IFieldState, IValidationResult } from "../elements/Validation";
@@ -124,8 +124,6 @@ export default class CreateChannelDialog extends React.Component<IProps, IState>
         if (this.props.parentSpace && this.state.joinRule === JoinRule.Restricted) {
             opts.joinRule = JoinRule.Restricted;
         }
-
-        opts.historyVisibility = HistoryVisibility.WorldReadable;
 
         return opts;
     }

--- a/src/matrix-react-sdk/src/components/views/dialogs/CreateRoomDialog.tsx
+++ b/src/matrix-react-sdk/src/components/views/dialogs/CreateRoomDialog.tsx
@@ -17,7 +17,7 @@ limitations under the License.
 
 import React, { useState, useRef, memo, ChangeEvent } from "react";
 import { RoomType } from "matrix-js-sdk/src/@types/event";
-import { JoinRule } from "matrix-js-sdk/src/@types/partials";
+import { HistoryVisibility, JoinRule } from "matrix-js-sdk/src/@types/partials";
 
 import { _t } from "../../../languageHandler";
 import { IOpts } from "../../../createRoom";
@@ -99,6 +99,7 @@ const CreateRoomDialog: React.FC<IProps> = ({
         onFinished(true, {
             roomType: type,
             joinRule: JoinRule.Invite,
+            historyVisibility: HistoryVisibility.Invited,
             avatar,
             createOpts: {
                 name,

--- a/src/matrix-react-sdk/src/components/views/dialogs/create_space/AddChannelDialog.tsx
+++ b/src/matrix-react-sdk/src/components/views/dialogs/create_space/AddChannelDialog.tsx
@@ -120,7 +120,6 @@ const AddChannelDialog: React.FC<IProps> = ({ stepIndex, onStepChange, spaceId, 
                     inlineErrors: true,
                     parentSpace: spaceRoom,
                     joinRule: JoinRule.Restricted, // 创建对社区内可见频道
-                    suggested: true,
                 });
             }),
         );

--- a/src/matrix-react-sdk/src/components/views/right_panel/RoomHeaderButtons.tsx
+++ b/src/matrix-react-sdk/src/components/views/right_panel/RoomHeaderButtons.tsx
@@ -46,6 +46,10 @@ import { EchoChamber } from "matrix-react-sdk/src/stores/local-echo/EchoChamber"
 import { CachedRoomKey, RoomEchoChamber } from "matrix-react-sdk/src/stores/local-echo/RoomEchoChamber";
 import { PROPERTY_UPDATED } from "matrix-react-sdk/src/stores/local-echo/GenericEchoChamber";
 import { doesRoomOrThreadHaveUnreadMessages } from "../../../Unread";
+import { MatrixClient } from "matrix-js-sdk/src/client";
+import { RoomStateEvent } from "matrix-js-sdk/src/models/room-state";
+import { MatrixEvent } from "matrix-js-sdk/src/models/event";
+import { EventType } from "matrix-js-sdk/src/@types/event";
 
 const ROOM_INFO_PHASES = [
     RightPanelPhases.RoomSummary,
@@ -89,12 +93,15 @@ interface IProps {
 interface IState {
     notificationState: RoomNotifState;
     showRoomNotificationContextMenu: boolean;
+    displayMemberList: boolean;
 }
 
 export default class RoomHeaderButtons extends HeaderButtons<IProps> {
     private notificationBtnRef = createRef<HTMLDivElement>();
     private static readonly THREAD_PHASES = [RightPanelPhases.ThreadPanel, RightPanelPhases.ThreadView];
     private echoChamber: RoomEchoChamber;
+    private cli: MatrixClient = MatrixClientPeg.get();
+    private myUserId = this.cli.getUserId();
     // private state: IState;
 
     public constructor(props: IProps) {
@@ -103,11 +110,13 @@ export default class RoomHeaderButtons extends HeaderButtons<IProps> {
         this.state = {
             notificationState: this.echoChamber?.notificationVolume,
             showRoomNotificationContextMenu: false,
+            displayMemberList: false, // 是否展示成员列表
         };
     }
 
     public componentDidMount(): void {
         super.componentDidMount();
+        this.updatePermissions(this.props.room);
         // Notification badge may change if the notification counts from the
         // server change, if a new thread is created or updated, or if a
         // receipt is sent in the thread.
@@ -121,6 +130,7 @@ export default class RoomHeaderButtons extends HeaderButtons<IProps> {
         this.props.room?.on(ThreadEvent.Update, this.onNotificationUpdate);
         this.echoChamber?.on(PROPERTY_UPDATED, this.onRoomPropertyUpdate);
         this.onNotificationUpdate();
+        this.props.room?.on(RoomStateEvent.Events, this.onRoomStateEvents);
     }
 
     public componentWillUnmount(): void {
@@ -134,6 +144,25 @@ export default class RoomHeaderButtons extends HeaderButtons<IProps> {
         this.props.room?.off(ThreadEvent.New, this.onNotificationUpdate);
         this.props.room?.off(ThreadEvent.Update, this.onNotificationUpdate);
         this.echoChamber?.on(PROPERTY_UPDATED, this.onRoomPropertyUpdate);
+        this.props.room?.off(RoomStateEvent.Events, this.onRoomStateEvents);
+    }
+
+    private onRoomStateEvents = (ev: MatrixEvent) => {
+        switch (ev.getType()) {
+            case EventType.RoomPowerLevels:
+                this.updatePermissions(this.props.room);
+                break;
+        }
+    };
+
+    // 更新当前用户权限
+    private updatePermissions(room: Room): void {
+        if (!room) return;
+
+        const displayMemberList = room.displayMemberList(this.myUserId);
+        this.setState({
+            displayMemberList,
+        });
     }
 
     private onRoomPropertyUpdate = (property: CachedRoomKey): void => {
@@ -145,6 +174,7 @@ export default class RoomHeaderButtons extends HeaderButtons<IProps> {
             threadNotificationColor: this.notificationColor,
             notificationState: this.echoChamber?.notificationVolume,
         });
+        this.updatePermissions(this.props.room);
     };
 
     private get notificationColor(): NotificationColor {
@@ -359,16 +389,17 @@ export default class RoomHeaderButtons extends HeaderButtons<IProps> {
                     />,
                 );
 
-            rightPanelPhaseButtons.set(
-                RightPanelPhases.RoomMemberList,
-                <HeaderButton
-                    key="roomMembersButton"
-                    name="roomMembersButton"
-                    title={"成员列表"}
-                    isHighlighted={this.isPhase(RightPanelPhases.RoomMemberList)}
-                    onClick={this.onRoomMemberListClicked}
-                />,
-            );
+            this.state.displayMemberList &&
+                rightPanelPhaseButtons.set(
+                    RightPanelPhases.RoomMemberList,
+                    <HeaderButton
+                        key="roomMembersButton"
+                        name="roomMembersButton"
+                        title={"成员列表"}
+                        isHighlighted={this.isPhase(RightPanelPhases.RoomMemberList)}
+                        onClick={this.onRoomMemberListClicked}
+                    />,
+                );
 
             !isHomeSpace &&
                 rightPanelPhaseButtons.set(

--- a/src/matrix-react-sdk/src/components/views/right_panel/RoomHeaderButtons.tsx
+++ b/src/matrix-react-sdk/src/components/views/right_panel/RoomHeaderButtons.tsx
@@ -50,6 +50,7 @@ import { MatrixClient } from "matrix-js-sdk/src/client";
 import { RoomStateEvent } from "matrix-js-sdk/src/models/room-state";
 import { MatrixEvent } from "matrix-js-sdk/src/models/event";
 import { EventType } from "matrix-js-sdk/src/@types/event";
+import { RoomMemberEvent } from "matrix-js-sdk/src/models/room-member";
 
 const ROOM_INFO_PHASES = [
     RightPanelPhases.RoomSummary,
@@ -120,6 +121,7 @@ export default class RoomHeaderButtons extends HeaderButtons<IProps> {
         // Notification badge may change if the notification counts from the
         // server change, if a new thread is created or updated, or if a
         // receipt is sent in the thread.
+        this.cli.on(RoomMemberEvent.PowerLevel, this.onRoomMemberPowerLevel);
         this.props.room?.on(RoomEvent.UnreadNotifications, this.onNotificationUpdate);
         this.props.room?.on(RoomEvent.Receipt, this.onNotificationUpdate);
         this.props.room?.on(RoomEvent.Timeline, this.onNotificationUpdate);
@@ -135,6 +137,7 @@ export default class RoomHeaderButtons extends HeaderButtons<IProps> {
 
     public componentWillUnmount(): void {
         super.componentWillUnmount();
+        this.cli.off(RoomMemberEvent.PowerLevel, this.onRoomMemberPowerLevel);
         this.props.room?.off(RoomEvent.UnreadNotifications, this.onNotificationUpdate);
         this.props.room?.off(RoomEvent.Receipt, this.onNotificationUpdate);
         this.props.room?.off(RoomEvent.Timeline, this.onNotificationUpdate);
@@ -154,6 +157,11 @@ export default class RoomHeaderButtons extends HeaderButtons<IProps> {
                 this.setDisplayMemberList(this.props.room);
                 break;
         }
+    };
+
+    // 用户角色（powerLevel）更新
+    private onRoomMemberPowerLevel = (ev: MatrixEvent) => {
+        this.setDisplayMemberList(this.props.room);
     };
 
     private setDisplayMemberList(room: Room): boolean {

--- a/src/matrix-react-sdk/src/components/views/rooms/Autocomplete.tsx
+++ b/src/matrix-react-sdk/src/components/views/rooms/Autocomplete.tsx
@@ -121,7 +121,7 @@ export default class Autocomplete extends React.PureComponent<IProps, IState> {
     private onRoomStateEvents = (ev: MatrixEvent) => {
         switch (ev.getType()) {
             case EventType.RoomPowerLevels:
-                // 权限更新
+                // powerLevel更新
                 this.setDisplayMemberList(this.props.room);
                 break;
         }

--- a/src/matrix-react-sdk/src/components/views/rooms/Autocomplete.tsx
+++ b/src/matrix-react-sdk/src/components/views/rooms/Autocomplete.tsx
@@ -28,6 +28,7 @@ import { MatrixClientPeg } from "matrix-react-sdk/src/MatrixClientPeg";
 import { RoomStateEvent } from "matrix-js-sdk/src/models/room-state";
 import { MatrixEvent } from "matrix-js-sdk/src/models/event";
 import { EventType } from "matrix-js-sdk/src/@types/event";
+import { RoomMemberEvent } from "matrix-js-sdk/src/models/room-member";
 
 const MAX_PROVIDER_MATCHES = 20;
 
@@ -95,6 +96,7 @@ export default class Autocomplete extends React.PureComponent<IProps, IState> {
         const displayMemberList = this.setDisplayMemberList(this.props.room);
         this.applyNewProps(displayMemberList);
         this.props.room?.on(RoomStateEvent.Events, this.onRoomStateEvents);
+        this.cli.on(RoomMemberEvent.PowerLevel, this.onRoomMemberPowerLevel);
     }
 
     private applyNewProps(displayMemberList: boolean, oldQuery?: string, oldRoom?: Room): void {
@@ -116,6 +118,7 @@ export default class Autocomplete extends React.PureComponent<IProps, IState> {
     public componentWillUnmount(): void {
         this.autocompleter.destroy();
         this.props.room?.off(RoomStateEvent.Events, this.onRoomStateEvents);
+        this.cli.off(RoomMemberEvent.PowerLevel, this.onRoomMemberPowerLevel);
     }
 
     private onRoomStateEvents = (ev: MatrixEvent) => {
@@ -125,6 +128,11 @@ export default class Autocomplete extends React.PureComponent<IProps, IState> {
                 this.setDisplayMemberList(this.props.room);
                 break;
         }
+    };
+
+    // 用户角色（powerLevel）更新
+    private onRoomMemberPowerLevel = (ev: MatrixEvent) => {
+        this.setDisplayMemberList(this.props.room);
     };
 
     private setDisplayMemberList(room: Room): boolean {

--- a/src/matrix-react-sdk/src/components/views/rooms/EntityTile.tsx
+++ b/src/matrix-react-sdk/src/components/views/rooms/EntityTile.tsx
@@ -20,21 +20,11 @@ import React from "react";
 import classNames from "classnames";
 
 import AccessibleButton, { ButtonEvent } from "../elements/AccessibleButton";
-import { _t, _td } from "../../../languageHandler";
+import { _t } from "../../../languageHandler";
 import E2EIcon, { E2EState } from "./E2EIcon";
 import BaseAvatar from "../avatars/BaseAvatar";
 import PresenceLabel from "./PresenceLabel";
-export enum PowerLevel {
-    Admin = 100,
-    Moderator = 50,
-    Default = 0,
-}
-
-export const PowerLabel: Record<PowerLevel, string> = {
-    [PowerLevel.Admin]: _td("Admin"),
-    [PowerLevel.Moderator]: _td("Mod"),
-    [PowerLevel.Default]: _td("Default"),
-};
+import { PowerLabel, PowerLevel } from "matrix-react-sdk/src/powerLevel";
 
 export type PresenceState = "offline" | "online" | "unavailable";
 

--- a/src/matrix-react-sdk/src/components/views/rooms/RoomList.tsx
+++ b/src/matrix-react-sdk/src/components/views/rooms/RoomList.tsx
@@ -54,9 +54,9 @@ import {
     ISuggestedRoom,
     MetaSpace,
     SpaceKey,
+    UPDATE_FILTERED_SUGGESTED_ROOMS,
     UPDATE_SELECTED_SPACE,
     UPDATE_SPACE_TAGS,
-    UPDATE_SUGGESTED_ROOMS,
 } from "../../../stores/spaces";
 import SpaceStore from "../../../stores/spaces/SpaceStore";
 import { arrayFastClone, arrayHasDiff } from "../../../utils/arrays";
@@ -410,7 +410,7 @@ export default class RoomList extends React.PureComponent<IProps, IState> {
 
         this.state = {
             sublists: {},
-            suggestedRooms: SpaceStore.instance.suggestedRooms,
+            suggestedRooms: SpaceStore.instance.filteredSuggestedRooms,
             feature_favourite_messages: SettingsStore.getValue("feature_favourite_messages"),
             spaceTags: [],
             spaceTagIds: [],
@@ -423,7 +423,7 @@ export default class RoomList extends React.PureComponent<IProps, IState> {
     public componentDidMount(): void {
         this.dispatcherRef = defaultDispatcher.register(this.onAction);
         SdkContextClass.instance.roomViewStore.on(UPDATE_EVENT, this.onRoomViewStoreUpdate);
-        SpaceStore.instance.on(UPDATE_SUGGESTED_ROOMS, this.updateSuggestedRooms);
+        SpaceStore.instance.on(UPDATE_FILTERED_SUGGESTED_ROOMS, this.updateSuggestedRooms);
         RoomListStore.instance.on(LISTS_UPDATE_EVENT, this.updateLists);
         this.favouriteMessageWatcher = SettingsStore.watchSetting(
             "feature_favourite_messages",
@@ -449,7 +449,7 @@ export default class RoomList extends React.PureComponent<IProps, IState> {
     }
 
     public componentWillUnmount(): void {
-        SpaceStore.instance.off(UPDATE_SUGGESTED_ROOMS, this.updateSuggestedRooms);
+        SpaceStore.instance.off(UPDATE_FILTERED_SUGGESTED_ROOMS, this.updateSuggestedRooms);
         RoomListStore.instance.off(LISTS_UPDATE_EVENT, this.updateLists);
         SettingsStore.unwatchSetting(this.favouriteMessageWatcher);
         if (this.dispatcherRef) defaultDispatcher.unregister(this.dispatcherRef);
@@ -558,8 +558,8 @@ export default class RoomList extends React.PureComponent<IProps, IState> {
         return room;
     };
 
-    private updateSuggestedRooms = (suggestedRooms: ISuggestedRoom[]): void => {
-        this.setState({ suggestedRooms });
+    private updateSuggestedRooms = (filteredSuggestedRooms: ISuggestedRoom[]): void => {
+        this.setState({ suggestedRooms: filteredSuggestedRooms });
     };
 
     private updateLists = (): void => {

--- a/src/matrix-react-sdk/src/components/views/settings/ChannelEnableMemberListSettings.tsx
+++ b/src/matrix-react-sdk/src/components/views/settings/ChannelEnableMemberListSettings.tsx
@@ -14,9 +14,9 @@ interface IProps {
 }
 
 // 获取"是否允许普通用户展示成员列表"该配置项的值
-function getRoomEnableDefaultUserSendMsg(content: IEnableDefaultUserMemberListContent): boolean {
-    const { enable: enableDefaultUserSendMsg = true } = content ?? {};
-    return enableDefaultUserSendMsg;
+function getRoomEnableDefaultUserMemberList(content: IEnableDefaultUserMemberListContent): boolean {
+    const { enable = true } = content ?? {};
+    return enable;
 }
 
 const ChannelEnableMemberListSettings: React.FC<IProps> = ({ room, onError }) => {
@@ -35,7 +35,7 @@ const ChannelEnableMemberListSettings: React.FC<IProps> = ({ room, onError }) =>
 
     const [value, setValue] = useState<boolean>(true);
     useEffect(() => {
-        setValue(getRoomEnableDefaultUserSendMsg(content));
+        setValue(getRoomEnableDefaultUserMemberList(content));
     }, [content]);
 
     const changeRoomPowerLevels = (room: Room, enable: boolean): Promise<ISendEventResponse> => {

--- a/src/matrix-react-sdk/src/components/views/settings/ChannelEnableMemberListSettings.tsx
+++ b/src/matrix-react-sdk/src/components/views/settings/ChannelEnableMemberListSettings.tsx
@@ -1,0 +1,73 @@
+import React, { useContext, useState, useEffect, memo } from "react";
+import MatrixClientContext from "../../../contexts/MatrixClientContext";
+import { Room } from "matrix-js-sdk/src/models/room";
+import LabelledToggleSwitch from "matrix-react-sdk/src/components/views/elements/LabelledToggleSwitch";
+import { IEnableDefaultUserMemberListContent } from "matrix-js-sdk/src/@types/partials";
+import { AdditionalEventType, useRoomState } from "matrix-react-sdk/src/hooks/room/useRoomState";
+import { ISendEventResponse } from "matrix-js-sdk/src/@types/requests";
+import { EventType } from "matrix-js-sdk/src/@types/event";
+import { getPowerLevelByEnableDefaultUserMemberList } from "matrix-react-sdk/src/powerLevel";
+
+interface IProps {
+    room: Room;
+    onError?(error: Error): void;
+}
+
+// 获取"是否允许普通用户展示成员列表"该配置项的值
+function getRoomEnableDefaultUserSendMsg(content: IEnableDefaultUserMemberListContent): boolean {
+    const { enable: enableDefaultUserSendMsg = true } = content ?? {};
+    return enableDefaultUserSendMsg;
+}
+
+const ChannelEnableMemberListSettings: React.FC<IProps> = ({ room, onError }) => {
+    const cli = useContext(MatrixClientContext);
+
+    const { disabled, content, setContent, sendStateEvent } = useRoomState<IEnableDefaultUserMemberListContent>(
+        cli,
+        room,
+        AdditionalEventType.RoomEnableDefaultUserMemberList,
+        async (newContent) => {
+            await sendStateEvent(newContent); // 修改配置项
+            await changeRoomPowerLevels(room, newContent.enable); // 修改配置后，同时修改powerLevel display_member_list一项，控制谁可以展示成员列表
+        },
+        onError,
+    );
+
+    const [value, setValue] = useState<boolean>(true);
+    useEffect(() => {
+        setValue(getRoomEnableDefaultUserSendMsg(content));
+    }, [content]);
+
+    const changeRoomPowerLevels = (room: Room, enable: boolean): Promise<ISendEventResponse> => {
+        const plEvent = room?.currentState.getStateEvents(EventType.RoomPowerLevels, "");
+
+        const { events, users, ...statePowerLevels } = plEvent?.getContent() ?? {};
+        const plContent = {
+            ...statePowerLevels,
+            ...getPowerLevelByEnableDefaultUserMemberList(enable),
+            events,
+            users,
+        };
+
+        return cli.sendStateEvent(room.roomId, EventType.RoomPowerLevels, plContent);
+    };
+
+    const onToggleMemberListEnable = (checked: boolean) => {
+        const newContent: IEnableDefaultUserMemberListContent = {
+            enable: checked,
+        };
+        setContent(newContent);
+    };
+
+    return (
+        <>
+            <LabelledToggleSwitch
+                label={"是否显示成员列表"}
+                disabled={disabled}
+                value={value}
+                onChange={onToggleMemberListEnable}
+            />
+        </>
+    );
+};
+export default memo(ChannelEnableMemberListSettings);

--- a/src/matrix-react-sdk/src/components/views/settings/ChannelEnableSendMsgSettings.tsx
+++ b/src/matrix-react-sdk/src/components/views/settings/ChannelEnableSendMsgSettings.tsx
@@ -31,8 +31,8 @@ interface IProps {
 
 // 获取"是否允许普通用户发送消息"该配置项的值
 function getRoomEnableDefaultUserSendMsg(content: IEnableDefaultUserSendMsgEventContent): boolean {
-    const { enable: enableDefaultUserSendMsg = true } = content ?? {};
-    return enableDefaultUserSendMsg;
+    const { enable = true } = content ?? {};
+    return enable;
 }
 
 const ChannelEnableSendMsgSettings: React.FC<IProps> = ({ room, onError }) => {

--- a/src/matrix-react-sdk/src/components/views/settings/ChannelEnableSendMsgSettings.tsx
+++ b/src/matrix-react-sdk/src/components/views/settings/ChannelEnableSendMsgSettings.tsx
@@ -21,7 +21,7 @@ import LabelledToggleSwitch from "matrix-react-sdk/src/components/views/elements
 import { IEnableDefaultUserSendMsgEventContent } from "matrix-js-sdk/src/@types/partials";
 import { EventType } from "matrix-js-sdk/src/@types/event";
 import { ISendEventResponse } from "matrix-js-sdk/src/@types/requests";
-import { getEventsDefaultByEnableDefaultUserSendMsg } from "matrix-react-sdk/src/powerLevel";
+import { getPowerLevelByEnableDefaultUserSendMsg } from "matrix-react-sdk/src/powerLevel";
 import { AdditionalEventType, useRoomState } from "matrix-react-sdk/src/hooks/room/useRoomState";
 
 interface IProps {
@@ -60,7 +60,7 @@ const ChannelEnableSendMsgSettings: React.FC<IProps> = ({ room, onError }) => {
         const { events, users, ...statePowerLevels } = plEvent?.getContent() ?? {};
         const plContent = {
             ...statePowerLevels,
-            events_default: getEventsDefaultByEnableDefaultUserSendMsg(enable),
+            ...getPowerLevelByEnableDefaultUserSendMsg(enable),
             events,
             users,
         };

--- a/src/matrix-react-sdk/src/components/views/settings/ChannelEnableSendMsgSettings.tsx
+++ b/src/matrix-react-sdk/src/components/views/settings/ChannelEnableSendMsgSettings.tsx
@@ -1,0 +1,89 @@
+/*
+Copyright 2019 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React, { useContext, useState, useEffect, memo } from "react";
+import MatrixClientContext from "../../../contexts/MatrixClientContext";
+import { Room } from "matrix-js-sdk/src/models/room";
+import LabelledToggleSwitch from "matrix-react-sdk/src/components/views/elements/LabelledToggleSwitch";
+import { IEnableDefaultUserSendMsgEventContent } from "matrix-js-sdk/src/@types/partials";
+import { EventType } from "matrix-js-sdk/src/@types/event";
+import { ISendEventResponse } from "matrix-js-sdk/src/@types/requests";
+import { getEventsDefaultByEnableDefaultUserSendMsg } from "matrix-react-sdk/src/powerLevel";
+import { AdditionalEventType, useRoomState } from "matrix-react-sdk/src/hooks/room/useRoomState";
+
+interface IProps {
+    room: Room;
+    onError?(error: Error): void;
+}
+
+// 获取"是否允许普通用户发送消息"该配置项的值
+function getRoomEnableDefaultUserSendMsg(content: IEnableDefaultUserSendMsgEventContent): boolean {
+    const { enable: enableDefaultUserSendMsg = true } = content ?? {};
+    return enableDefaultUserSendMsg;
+}
+
+const ChannelEnableSendMsgSettings: React.FC<IProps> = ({ room, onError }) => {
+    const cli = useContext(MatrixClientContext);
+
+    const { disabled, content, setContent, sendStateEvent } = useRoomState<IEnableDefaultUserSendMsgEventContent>(
+        cli,
+        room,
+        AdditionalEventType.RoomEnableDefaultUserSendMsg,
+        async (newContent) => {
+            await sendStateEvent(newContent); // 修改配置项
+            await changeRoomPowerLevels(room, newContent.enable); // 修改配置后，同时修改powerLevel events_default一项，控制谁可以发送消息
+        },
+        onError,
+    );
+
+    const [value, setValue] = useState<boolean>(true);
+    useEffect(() => {
+        setValue(getRoomEnableDefaultUserSendMsg(content));
+    }, [content]);
+
+    const changeRoomPowerLevels = (room: Room, enable: boolean): Promise<ISendEventResponse> => {
+        const plEvent = room?.currentState.getStateEvents(EventType.RoomPowerLevels, "");
+
+        const { events, users, ...statePowerLevels } = plEvent?.getContent() ?? {};
+        const plContent = {
+            ...statePowerLevels,
+            events_default: getEventsDefaultByEnableDefaultUserSendMsg(enable),
+            events,
+            users,
+        };
+
+        return cli.sendStateEvent(room.roomId, EventType.RoomPowerLevels, plContent);
+    };
+
+    const onToggleSendMsgEnable = (checked: boolean) => {
+        const newContent: IEnableDefaultUserSendMsgEventContent = {
+            enable: checked,
+        };
+        setContent(newContent);
+    };
+
+    return (
+        <>
+            <LabelledToggleSwitch
+                label={"允许普通用户发送消息"}
+                disabled={disabled}
+                value={value}
+                onChange={onToggleSendMsgEnable}
+            />
+        </>
+    );
+};
+export default memo(ChannelEnableSendMsgSettings);

--- a/src/matrix-react-sdk/src/components/views/settings/RoomEnableMemberListSetting.tsx
+++ b/src/matrix-react-sdk/src/components/views/settings/RoomEnableMemberListSetting.tsx
@@ -1,42 +1,28 @@
-import React, { useContext, useState, useEffect, memo } from "react";
+import React, { useContext, memo } from "react";
 import MatrixClientContext from "../../../contexts/MatrixClientContext";
 import { Room } from "matrix-js-sdk/src/models/room";
 import LabelledToggleSwitch from "matrix-react-sdk/src/components/views/elements/LabelledToggleSwitch";
-import { IEnableDefaultUserMemberListContent } from "matrix-js-sdk/src/@types/partials";
-import { AdditionalEventType, useRoomState } from "matrix-react-sdk/src/hooks/room/useRoomState";
 import { ISendEventResponse } from "matrix-js-sdk/src/@types/requests";
 import { EventType } from "matrix-js-sdk/src/@types/event";
 import { getPowerLevelByEnableDefaultUserMemberList } from "matrix-react-sdk/src/powerLevel";
+import { useRoomEnableMemberList } from "matrix-react-sdk/src/hooks/room/useRoomEnableMemberList";
 
 interface IProps {
     room: Room;
     onError?(error: Error): void;
 }
 
-// 获取"是否允许普通用户展示成员列表"该配置项的值
-function getRoomEnableDefaultUserMemberList(content: IEnableDefaultUserMemberListContent): boolean {
-    const { enable = true } = content ?? {};
-    return enable;
-}
-
-const ChannelEnableMemberListSettings: React.FC<IProps> = ({ room, onError }) => {
+const RoomEnableMemberListSetting: React.FC<IProps> = ({ room, onError }) => {
     const cli = useContext(MatrixClientContext);
 
-    const { disabled, content, setContent, sendStateEvent } = useRoomState<IEnableDefaultUserMemberListContent>(
+    const { disabled, value, setValue } = useRoomEnableMemberList(
         cli,
         room,
-        AdditionalEventType.RoomEnableDefaultUserMemberList,
-        async (newContent) => {
-            await sendStateEvent(newContent); // 修改配置项
-            await changeRoomPowerLevels(room, newContent.enable); // 修改配置后，同时修改powerLevel display_member_list一项，控制谁可以展示成员列表
+        (newContent) => {
+            changeRoomPowerLevels(room, newContent.enable); // 修改配置后，同时修改powerLevel display_member_list一项，控制谁可以展示成员列表
         },
         onError,
     );
-
-    const [value, setValue] = useState<boolean>(true);
-    useEffect(() => {
-        setValue(getRoomEnableDefaultUserMemberList(content));
-    }, [content]);
 
     const changeRoomPowerLevels = (room: Room, enable: boolean): Promise<ISendEventResponse> => {
         const plEvent = room?.currentState.getStateEvents(EventType.RoomPowerLevels, "");
@@ -53,10 +39,7 @@ const ChannelEnableMemberListSettings: React.FC<IProps> = ({ room, onError }) =>
     };
 
     const onToggleMemberListEnable = (checked: boolean) => {
-        const newContent: IEnableDefaultUserMemberListContent = {
-            enable: checked,
-        };
-        setContent(newContent);
+        setValue(checked);
     };
 
     return (
@@ -70,4 +53,4 @@ const ChannelEnableMemberListSettings: React.FC<IProps> = ({ room, onError }) =>
         </>
     );
 };
-export default memo(ChannelEnableMemberListSettings);
+export default memo(RoomEnableMemberListSetting);

--- a/src/matrix-react-sdk/src/components/views/settings/SpaceAndChannelJoinRuleSettings.tsx
+++ b/src/matrix-react-sdk/src/components/views/settings/SpaceAndChannelJoinRuleSettings.tsx
@@ -82,12 +82,14 @@ const SpaceAndChannelJoinRuleSettings: React.FC<IProps> = ({ room, onError, befo
                   {
                       value: JoinRule.Public, // 用于公开社区
                       label: _t("Public"),
+                      description: "允许普通用户邀请其他用户加入到当前社区",
                   },
               ]
             : [
                   {
                       value: JoinRule.Restricted, // 用于社区内公开频道（对社区内成员可见）
                       label: _t("Public"),
+                      description: "社区内所有用户可访问当前频道",
                       // if there are 0 allowed spaces then render it as invite only instead
                       checked: joinRule === JoinRule.Restricted && !!restrictedAllowRoomIds?.length,
                   },
@@ -95,6 +97,9 @@ const SpaceAndChannelJoinRuleSettings: React.FC<IProps> = ({ room, onError, befo
         {
             value: JoinRule.Invite, // 用于私密社区 || 私密频道
             label: _t("Private"),
+            description: room.isSpaceRoom()
+                ? "仅管理员和协管员可邀请用户到当前社区"
+                : "仅社区管理员和协管员可邀请用户到当前频道",
         },
     ];
 

--- a/src/matrix-react-sdk/src/components/views/settings/tabs/room/GeneralRoomSettingsTab.tsx
+++ b/src/matrix-react-sdk/src/components/views/settings/tabs/room/GeneralRoomSettingsTab.tsx
@@ -20,8 +20,8 @@ import RoomNameSetting from "matrix-react-sdk/src/components/views/room_settings
 import RoomTopicSetting from "matrix-react-sdk/src/components/views/room_settings/RoomTopicSetting";
 import SpaceAndChannelJoinRuleSettings from "matrix-react-sdk/src/components/views/settings/SpaceAndChannelJoinRuleSettings";
 import { _t } from "matrix-react-sdk/src/languageHandler";
-import ChannelEnableSendMsgSettings from "matrix-react-sdk/src/components/views/settings/ChannelEnableSendMsgSettings";
-import ChannelEnableMemberListSettings from "matrix-react-sdk/src/components/views/settings/ChannelEnableMemberListSettings";
+import RoomEnableSendMsgSetting from "matrix-react-sdk/src/components/views/settings/RoomEnableSendMsgSetting";
+import RoomEnableMemberListSetting from "matrix-react-sdk/src/components/views/settings/RoomEnableMemberListSetting";
 
 interface IProps {
     room: Room;
@@ -40,10 +40,10 @@ const GeneralRoomSettingsTab: React.FC<IProps> = ({ room }) => {
                 <SpaceAndChannelJoinRuleSettings room={room} />
             </div>
             <div className="mx_SettingsTab_section">
-                <ChannelEnableSendMsgSettings room={room} />
+                <RoomEnableSendMsgSetting room={room} />
             </div>
             <div className="mx_SettingsTab_section">
-                <ChannelEnableMemberListSettings room={room} />
+                <RoomEnableMemberListSetting room={room} />
             </div>
         </>
     );

--- a/src/matrix-react-sdk/src/components/views/settings/tabs/room/GeneralRoomSettingsTab.tsx
+++ b/src/matrix-react-sdk/src/components/views/settings/tabs/room/GeneralRoomSettingsTab.tsx
@@ -14,43 +14,34 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { ContextType } from "react";
-import MatrixClientContext from "../../../../../contexts/MatrixClientContext";
+import React, { memo } from "react";
 import { Room } from "matrix-js-sdk/src/models/room";
 import RoomNameSetting from "matrix-react-sdk/src/components/views/room_settings/RoomNameSetting";
 import RoomTopicSetting from "matrix-react-sdk/src/components/views/room_settings/RoomTopicSetting";
 import SpaceAndChannelJoinRuleSettings from "matrix-react-sdk/src/components/views/settings/SpaceAndChannelJoinRuleSettings";
 import { _t } from "matrix-react-sdk/src/languageHandler";
+import ChannelEnableSendMsgSettings from "matrix-react-sdk/src/components/views/settings/ChannelEnableSendMsgSettings";
 
 interface IProps {
     room: Room;
 }
 
-interface IState {}
-
-export default class GeneralRoomSettingsTab extends React.Component<IProps, IState> {
-    public static contextType = MatrixClientContext;
-    public context: ContextType<typeof MatrixClientContext>;
-
-    public constructor(props: IProps, context: ContextType<typeof MatrixClientContext>) {
-        super(props, context);
-
-        this.state = {};
-    }
-
-    public render(): React.ReactNode {
-        return (
-            <>
-                <div className="mx_SettingsTab_section">
-                    <RoomNameSetting room={this.props.room} />
-                    <hr />
-                    <RoomTopicSetting room={this.props.room} />
-                </div>
-                <div className="mx_SettingsTab_section">
-                    <p className="mx_SettingsTab_subTitle">{_t("Visibility")}</p>
-                    <SpaceAndChannelJoinRuleSettings room={this.props.room} />
-                </div>
-            </>
-        );
-    }
-}
+const GeneralRoomSettingsTab: React.FC<IProps> = ({ room }) => {
+    return (
+        <>
+            <div className="mx_SettingsTab_section">
+                <RoomNameSetting room={room} />
+                <hr />
+                <RoomTopicSetting room={room} />
+            </div>
+            <div className="mx_SettingsTab_section">
+                <p className="mx_SettingsTab_subTitle">{_t("Visibility")}</p>
+                <SpaceAndChannelJoinRuleSettings room={room} />
+            </div>
+            <div className="mx_SettingsTab_section">
+                <ChannelEnableSendMsgSettings room={room} />
+            </div>
+        </>
+    );
+};
+export default memo(GeneralRoomSettingsTab);

--- a/src/matrix-react-sdk/src/components/views/settings/tabs/room/GeneralRoomSettingsTab.tsx
+++ b/src/matrix-react-sdk/src/components/views/settings/tabs/room/GeneralRoomSettingsTab.tsx
@@ -21,6 +21,7 @@ import RoomTopicSetting from "matrix-react-sdk/src/components/views/room_setting
 import SpaceAndChannelJoinRuleSettings from "matrix-react-sdk/src/components/views/settings/SpaceAndChannelJoinRuleSettings";
 import { _t } from "matrix-react-sdk/src/languageHandler";
 import ChannelEnableSendMsgSettings from "matrix-react-sdk/src/components/views/settings/ChannelEnableSendMsgSettings";
+import ChannelEnableMemberListSettings from "matrix-react-sdk/src/components/views/settings/ChannelEnableMemberListSettings";
 
 interface IProps {
     room: Room;
@@ -40,6 +41,9 @@ const GeneralRoomSettingsTab: React.FC<IProps> = ({ room }) => {
             </div>
             <div className="mx_SettingsTab_section">
                 <ChannelEnableSendMsgSettings room={room} />
+            </div>
+            <div className="mx_SettingsTab_section">
+                <ChannelEnableMemberListSettings room={room} />
             </div>
         </>
     );

--- a/src/matrix-react-sdk/src/components/views/settings/tabs/room/RolesRoomSettingsTab.tsx
+++ b/src/matrix-react-sdk/src/components/views/settings/tabs/room/RolesRoomSettingsTab.tsx
@@ -38,7 +38,7 @@ import IconizedContextMenu, {
     IconizedContextMenuOption,
 } from "matrix-react-sdk/src/components/views/context_menus/IconizedContextMenu";
 import { aboveLeftOf } from "matrix-react-sdk/src/components/structures/ContextMenu";
-import { PowerLabel, PowerLevel } from "matrix-react-sdk/src/components/views/rooms/EntityTile";
+import { PowerLabel, PowerLevel } from "matrix-react-sdk/src/powerLevel";
 import AutoHideScrollbar from "matrix-react-sdk/src/components/structures/AutoHideScrollbar";
 import DropdownButton from "matrix-react-sdk/src/components/views/elements/DropdownButton";
 import RemoveUserDialog from "matrix-react-sdk/src/components/views/dialogs/RemoveMemberDialog";

--- a/src/matrix-react-sdk/src/components/views/spaces/SpaceCreateMenu.tsx
+++ b/src/matrix-react-sdk/src/components/views/spaces/SpaceCreateMenu.tsx
@@ -28,7 +28,7 @@ import React, {
 import classNames from "classnames";
 import { RoomType } from "matrix-js-sdk/src/@types/event";
 import { ICreateRoomOpts } from "matrix-js-sdk/src/@types/requests";
-import { HistoryVisibility, Preset, Visibility } from "matrix-js-sdk/src/@types/partials";
+import { HistoryVisibility, JoinRule, Preset, Visibility } from "matrix-js-sdk/src/@types/partials";
 import { logger } from "matrix-js-sdk/src/logger";
 
 import { _t } from "../../../languageHandler";
@@ -67,15 +67,11 @@ export const createSpace = async (
                 isPublic && (await MatrixClientPeg.get().doesServerSupportUnstableFeature("org.matrix.msc3827.stable"))
                     ? Visibility.Public
                     : Visibility.Private,
-            power_level_content_override: {
-                // Only allow Admins to write to the timeline to prevent hidden sync spam
-                events_default: 100,
-                invite: isPublic ? 0 : 50,
-            },
             room_alias_name: isPublic && alias ? alias.substring(1, alias.indexOf(":")) : undefined,
             topic,
             ...createOpts,
         },
+        joinRule: isPublic ? JoinRule.Public : JoinRule.Invite,
         avatar,
         roomType: RoomType.Space,
         historyVisibility: HistoryVisibility.WorldReadable,

--- a/src/matrix-react-sdk/src/components/views/spaces/SpaceSettingsGeneralTab.tsx
+++ b/src/matrix-react-sdk/src/components/views/spaces/SpaceSettingsGeneralTab.tsx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from "react";
+import React, { memo } from "react";
 import { Room } from "matrix-js-sdk/src/models/room";
 import RoomAvatarSettings from "matrix-react-sdk/src/components/views/room_settings/RoomAvatarSetting";
 import RoomNameSetting from "matrix-react-sdk/src/components/views/room_settings/RoomNameSetting";
@@ -44,4 +44,4 @@ const SpaceSettingsGeneralTab: React.FC<IProps> = ({ space }) => {
     );
 };
 
-export default SpaceSettingsGeneralTab;
+export default memo(SpaceSettingsGeneralTab);

--- a/src/matrix-react-sdk/src/createRoom.ts
+++ b/src/matrix-react-sdk/src/createRoom.ts
@@ -268,8 +268,9 @@ export default async function createRoom(opts: IOpts): Promise<string | null> {
     if (opts.parentSpace) {
         createOpts.initial_state.push(makeSpaceParentEvent(opts.parentSpace, true));
         if (!opts.historyVisibility) {
-            opts.historyVisibility =
-                createOpts.preset === Preset.PublicChat ? HistoryVisibility.WorldReadable : HistoryVisibility.Invited;
+            // opts.historyVisibility =
+            //     createOpts.preset === Preset.PublicChat ? HistoryVisibility.WorldReadable : HistoryVisibility.Invited;
+            opts.historyVisibility = HistoryVisibility.WorldReadable; // 社区内的频道历史消息可读
         }
 
         if (opts.joinRule === JoinRule.Restricted) {

--- a/src/matrix-react-sdk/src/createRoom.ts
+++ b/src/matrix-react-sdk/src/createRoom.ts
@@ -51,8 +51,7 @@ import { Tag } from "matrix-react-sdk/src/stores/room-list/models";
 import {
     getDefaultEventPowerLevels,
     getDefaultStatePowerLevels,
-    getPowerLevelByEnableDefaultUserMemberList,
-    getPowerLevelByEnableDefaultUserSendMsg,
+    getInitStatePowerLevels,
     isSpaceRoom,
 } from "matrix-react-sdk/src/powerLevel";
 import { AdditionalEventType } from "matrix-react-sdk/src/hooks/room/useRoomState";
@@ -197,12 +196,11 @@ export default async function createRoom(opts: IOpts): Promise<string | null> {
             createOpts.power_level_content_override = {
                 ...getDefaultStatePowerLevels(opts.roomType, opts.joinRule),
                 ...statePowerLevels,
-                ...(!isSpace
-                    ? {
-                          ...getPowerLevelByEnableDefaultUserSendMsg(opts.enableDefaultUserSendMsg),
-                          ...getPowerLevelByEnableDefaultUserMemberList(opts.enableDefaultUserMemberList),
-                      }
-                    : {}),
+                ...getInitStatePowerLevels({
+                    isSpace,
+                    enableDefaultUserSendMsg: opts.enableDefaultUserSendMsg,
+                    enableDefaultUserMemberList: opts.enableDefaultUserMemberList,
+                }),
                 events: {
                     ...getDefaultEventPowerLevels(opts.roomType),
                     ...events,

--- a/src/matrix-react-sdk/src/createRoom.ts
+++ b/src/matrix-react-sdk/src/createRoom.ts
@@ -268,8 +268,6 @@ export default async function createRoom(opts: IOpts): Promise<string | null> {
     if (opts.parentSpace) {
         createOpts.initial_state.push(makeSpaceParentEvent(opts.parentSpace, true));
         if (!opts.historyVisibility) {
-            // opts.historyVisibility =
-            //     createOpts.preset === Preset.PublicChat ? HistoryVisibility.WorldReadable : HistoryVisibility.Invited;
             opts.historyVisibility = HistoryVisibility.WorldReadable; // 社区内的频道历史消息可读
         }
 

--- a/src/matrix-react-sdk/src/hooks/room/useRoomEnableMemberList.ts
+++ b/src/matrix-react-sdk/src/hooks/room/useRoomEnableMemberList.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+import { MatrixClient } from "matrix-js-sdk/src/client";
+import { IEnableMemberListContent } from "matrix-js-sdk/src/@types/partials";
+import { Room } from "matrix-js-sdk/src/models/room";
+import { AdditionalEventType, useRoomState } from "matrix-react-sdk/src/hooks/room/useRoomState";
+
+interface RoomStateResult {
+    disabled: boolean;
+    value: boolean;
+    setValue: (value: boolean) => void;
+}
+
+// 获取"是否允许普通用户展示成员列表"该配置项的值
+function getRoomEnableMemberList(content: IEnableMemberListContent): boolean {
+    const { enable = true } = content ?? {};
+    return enable;
+}
+
+export function useRoomEnableMemberList(
+    cli: MatrixClient,
+    room: Room,
+    effectFn?: (newContent: IEnableMemberListContent) => Promise<void> | void,
+    errorFn?: (error: Error) => void,
+): RoomStateResult {
+    const { disabled, content, setContent, sendStateEvent } = useRoomState<IEnableMemberListContent>(
+        cli,
+        room,
+        AdditionalEventType.RoomEnableDefaultUserMemberList,
+        async (newContent) => {
+            await sendStateEvent(newContent); // 修改配置
+            await effectFn?.(newContent);
+        },
+        errorFn,
+    );
+
+    const [value, setValue] = useState<boolean>(true);
+    useEffect(() => {
+        setValue(getRoomEnableMemberList(content));
+    }, [content]);
+
+    const onChange = (enable: boolean) => {
+        const newContent: IEnableMemberListContent = {
+            enable,
+        };
+        setContent(newContent);
+    };
+
+    return {
+        disabled,
+        value,
+        setValue: onChange,
+    };
+}

--- a/src/matrix-react-sdk/src/hooks/room/useRoomEnableSendMsg.ts
+++ b/src/matrix-react-sdk/src/hooks/room/useRoomEnableSendMsg.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+import { MatrixClient } from "matrix-js-sdk/src/client";
+import { IEnableSendMsgEventContent } from "matrix-js-sdk/src/@types/partials";
+import { Room } from "matrix-js-sdk/src/models/room";
+import { AdditionalEventType, useRoomState } from "matrix-react-sdk/src/hooks/room/useRoomState";
+
+interface RoomStateResult {
+    disabled: boolean;
+    value: boolean;
+    setValue: (value: boolean) => void;
+}
+
+// 获取"是否允许普通用户发送消息"该配置项的值
+function getRoomEnableSendMsg(content: IEnableSendMsgEventContent): boolean {
+    const { enable = true } = content ?? {};
+    return enable;
+}
+
+export function useRoomEnableSendMsg(
+    cli: MatrixClient,
+    room: Room,
+    effectFn?: (newContent: IEnableSendMsgEventContent) => Promise<void> | void,
+    errorFn?: (error: Error) => void,
+): RoomStateResult {
+    const { disabled, content, setContent, sendStateEvent } = useRoomState<IEnableSendMsgEventContent>(
+        cli,
+        room,
+        AdditionalEventType.RoomEnableDefaultUserSendMsg,
+        async (newContent) => {
+            await sendStateEvent(newContent); // 修改配置
+            await effectFn?.(newContent);
+        },
+        errorFn,
+    );
+
+    const [value, setValue] = useState<boolean>(true);
+    useEffect(() => {
+        setValue(getRoomEnableSendMsg(content));
+    }, [content]);
+
+    const onChange = (enable: boolean) => {
+        const newContent: IEnableSendMsgEventContent = {
+            enable,
+        };
+        setContent(newContent);
+    };
+
+    return {
+        disabled,
+        value,
+        setValue: onChange,
+    };
+}

--- a/src/matrix-react-sdk/src/hooks/room/useRoomState.ts
+++ b/src/matrix-react-sdk/src/hooks/room/useRoomState.ts
@@ -36,8 +36,8 @@ export function useRoomState<T>(
     cli: MatrixClient,
     room: Room,
     eventType: EventType | AdditionalEventType,
-    setterFn,
-    errorFn,
+    setterFn?: (newContent: T) => Promise<void>,
+    errorFn?: (error: Error) => void,
 ): RoomStateResult<T> {
     // 判断权限
     const [disabled, setDisabled] = useState(() => !hasPermission(room, eventType, cli));
@@ -64,7 +64,7 @@ export function useRoomState<T>(
         [cli, room, eventType],
     );
 
-    const handleChange = async (newContent: T) => {
+    const onContentChange = async (newContent: T) => {
         setContent(newContent);
         try {
             await setterFn?.(newContent);
@@ -77,7 +77,7 @@ export function useRoomState<T>(
     return {
         disabled,
         content,
-        setContent: handleChange,
+        setContent: onContentChange,
         sendStateEvent,
     };
 }

--- a/src/matrix-react-sdk/src/hooks/room/useRoomState.ts
+++ b/src/matrix-react-sdk/src/hooks/room/useRoomState.ts
@@ -44,6 +44,12 @@ export function useRoomState<T>(
     useEffect(() => {
         setDisabled(!hasPermission(room, eventType, cli));
     }, [room, eventType, cli]);
+    // 订阅room powerLevels更改
+    useTypedEventEmitter(room.currentState, RoomStateEvent.Events, (ev: MatrixEvent) => {
+        if (ev.getType() !== EventType.RoomPowerLevels) return;
+        setDisabled(!hasPermission(room, eventType, cli));
+    });
+    // 订阅用户powerLevel值更改
     useTypedEventEmitter(cli, RoomMemberEvent.PowerLevel, (ev: MatrixEvent) => {
         setDisabled(!hasPermission(room, eventType, cli));
     });
@@ -53,6 +59,7 @@ export function useRoomState<T>(
     useEffect(() => {
         setContent(getRoomStateContent(room, eventType));
     }, [room, eventType]);
+    // 订阅eventType state更改
     useTypedEventEmitter(room.currentState, RoomStateEvent.Events, (ev: MatrixEvent) => {
         if (ev.getType() !== eventType) return;
         setContent(getRoomStateContent(room, eventType));

--- a/src/matrix-react-sdk/src/hooks/room/useRoomState.ts
+++ b/src/matrix-react-sdk/src/hooks/room/useRoomState.ts
@@ -10,8 +10,8 @@ import { ISendEventResponse } from "matrix-js-sdk/src/@types/requests";
 
 export enum AdditionalEventType {
     // Room state events
-    RoomEnableDefaultUserSendMsg = "m.room.enable_default_user_send_message", // 是否允许普通用户发送消息
-    RoomEnableDefaultUserMemberList = "m.room.enable_default_user_member_list", // 是否允许普通用户展示成员列表
+    RoomEnableDefaultUserSendMsg = "m.room.enable_default_user_send_message", // 启用|禁用普通用户发送消息
+    RoomEnableDefaultUserMemberList = "m.room.enable_default_user_member_list", // 启用|禁用普通用户展示成员列表
 }
 
 interface RoomStateResult<T> {

--- a/src/matrix-react-sdk/src/hooks/room/useRoomState.ts
+++ b/src/matrix-react-sdk/src/hooks/room/useRoomState.ts
@@ -1,0 +1,82 @@
+import { useEffect, useState, useCallback } from "react";
+import { MatrixClient } from "matrix-js-sdk/src/client";
+import { EventType } from "matrix-js-sdk/src/@types/event";
+import { MatrixEvent } from "matrix-js-sdk/src/models/event";
+import { Room } from "matrix-js-sdk/src/models/room";
+import { RoomStateEvent } from "matrix-js-sdk/src/models/room-state";
+import { useTypedEventEmitter } from "../useEventEmitter";
+import { RoomMemberEvent } from "matrix-js-sdk/src/models/room-member";
+import { ISendEventResponse } from "matrix-js-sdk/src/@types/requests";
+
+export enum AdditionalEventType {
+    // Room state events
+    RoomEnableDefaultUserSendMsg = "m.room.enable_default_user_send_message", // 是否允许普通用户发送消息
+}
+
+interface RoomStateResult<T> {
+    disabled: boolean;
+    content: T | null;
+    setContent: (newContent: T) => Promise<unknown>;
+    sendStateEvent: (newContent: T, stateKey?: string) => Promise<ISendEventResponse>;
+}
+
+// 是否有权限修改eventType对应的配置项
+const hasPermission = (room: Room, eventType: EventType | AdditionalEventType, cli: MatrixClient): boolean => {
+    return room.currentState.mayClientSendStateEvent(eventType, cli);
+};
+
+// 获取eventType对应配置项的内容
+function getRoomStateContent<T>(room: Room, eventType: EventType | AdditionalEventType): T | null {
+    const event = room.currentState.getStateEvents(eventType, "");
+    return event?.getContent() ?? null;
+}
+
+export function useRoomState<T>(
+    cli: MatrixClient,
+    room: Room,
+    eventType: EventType | AdditionalEventType,
+    setterFn,
+    errorFn,
+): RoomStateResult<T> {
+    // 判断权限
+    const [disabled, setDisabled] = useState(() => !hasPermission(room, eventType, cli));
+    useEffect(() => {
+        setDisabled(!hasPermission(room, eventType, cli));
+    }, [room, eventType, cli]);
+    useTypedEventEmitter(cli, RoomMemberEvent.PowerLevel, (ev: MatrixEvent) => {
+        setDisabled(!hasPermission(room, eventType, cli));
+    });
+
+    // eventType对应配置项内容
+    const [content, setContent] = useState<T | null>(() => getRoomStateContent<T>(room, eventType));
+    useEffect(() => {
+        setContent(getRoomStateContent(room, eventType));
+    }, [room, eventType]);
+    useTypedEventEmitter(room.currentState, RoomStateEvent.Events, (ev: MatrixEvent) => {
+        if (ev.getType() !== eventType) return;
+        setContent(getRoomStateContent(room, eventType));
+    });
+
+    // 修改配置项
+    const sendStateEvent = useCallback(
+        (newContent: T, stateKey = "") => cli.sendStateEvent(room.roomId, eventType, newContent, stateKey),
+        [cli, room, eventType],
+    );
+
+    const handleChange = async (newContent: T) => {
+        setContent(newContent);
+        try {
+            await setterFn?.(newContent);
+        } catch (error) {
+            setContent(getRoomStateContent(room, eventType));
+            errorFn?.(error);
+        }
+    };
+
+    return {
+        disabled,
+        content,
+        setContent: handleChange,
+        sendStateEvent,
+    };
+}

--- a/src/matrix-react-sdk/src/hooks/room/useRoomState.ts
+++ b/src/matrix-react-sdk/src/hooks/room/useRoomState.ts
@@ -11,6 +11,7 @@ import { ISendEventResponse } from "matrix-js-sdk/src/@types/requests";
 export enum AdditionalEventType {
     // Room state events
     RoomEnableDefaultUserSendMsg = "m.room.enable_default_user_send_message", // 是否允许普通用户发送消息
+    RoomEnableDefaultUserMemberList = "m.room.enable_default_user_member_list", // 是否允许普通用户展示成员列表
 }
 
 interface RoomStateResult<T> {
@@ -26,7 +27,7 @@ const hasPermission = (room: Room, eventType: EventType | AdditionalEventType, c
 };
 
 // 获取eventType对应配置项的内容
-function getRoomStateContent<T>(room: Room, eventType: EventType | AdditionalEventType): T | null {
+export function getRoomStateContent<T>(room: Room, eventType: EventType | AdditionalEventType): T | null {
     const event = room.currentState.getStateEvents(eventType, "");
     return event?.getContent() ?? null;
 }

--- a/src/matrix-react-sdk/src/hooks/room/useRoomState.ts
+++ b/src/matrix-react-sdk/src/hooks/room/useRoomState.ts
@@ -23,12 +23,12 @@ interface RoomStateResult<T> {
 
 // 是否有权限修改eventType对应的配置项
 const hasPermission = (room: Room, eventType: EventType | AdditionalEventType, cli: MatrixClient): boolean => {
-    return room.currentState.mayClientSendStateEvent(eventType, cli);
+    return cli && room?.currentState.mayClientSendStateEvent(eventType, cli);
 };
 
 // 获取eventType对应配置项的内容
 export function getRoomStateContent<T>(room: Room, eventType: EventType | AdditionalEventType): T | null {
-    const event = room.currentState.getStateEvents(eventType, "");
+    const event = room?.currentState.getStateEvents(eventType, "");
     return event?.getContent() ?? null;
 }
 

--- a/src/matrix-react-sdk/src/powerLevel.ts
+++ b/src/matrix-react-sdk/src/powerLevel.ts
@@ -46,14 +46,18 @@ interface EventPowerLevelDescriptorsMap {
     [eventType: string]: EventPowerLevelDescriptorItem;
 }
 
+export function isSpaceRoom(roomType: RoomType | string): boolean {
+    return roomType === RoomType.Space;
+}
+
 // state powerLevel
 export function getDefaultPowerLevels(roomType: RoomType | string, joinRule: JoinRule): PowerLevelsMap {
-    const isSpaceRoom = roomType === RoomType.Space;
+    const isSpace = isSpaceRoom(roomType);
     return {
         users_default: PowerLevel.Default,
         state_default: PowerLevel.Moderator,
-        events_default: isSpaceRoom ? PowerLevel.Admin : PowerLevel.Default, // 哪些角色可以发送消息
-        invite: isSpaceRoom && isPrivateRoom(joinRule) ? PowerLevel.Moderator : PowerLevel.Default, // 私密社区协管员及以上权限才可以邀请
+        events_default: isSpace ? PowerLevel.Admin : PowerLevel.Default, // 哪些角色可以发送消息
+        invite: isSpace && isPrivateRoom(joinRule) ? PowerLevel.Moderator : PowerLevel.Default, // 私密社区协管员及以上权限才可以邀请
         kick: PowerLevel.Moderator,
         ban: PowerLevel.Moderator,
         redact: PowerLevel.Moderator,
@@ -104,7 +108,7 @@ export function getPowerLevelsDescriptors(roomType: RoomType | string, joinRule)
 
 // event powerLevel
 export function getDefaultEventPowerLevels(roomType: RoomType | string): PowerLevelsMap {
-    const isSpaceRoom = roomType === RoomType.Space;
+    const isSpace = isSpaceRoom(roomType);
 
     return {
         [EventType.RoomAvatar]: PowerLevel.Moderator,
@@ -118,8 +122,8 @@ export function getDefaultEventPowerLevels(roomType: RoomType | string): PowerLe
         [EventType.RoomTombstone]: PowerLevel.Admin,
         [EventType.RoomEncryption]: PowerLevel.Admin,
         [EventType.RoomServerAcl]: PowerLevel.Admin,
-        [EventType.Reaction]: isSpaceRoom ? PowerLevel.Admin : PowerLevel.Default,
-        [EventType.RoomRedaction]: isSpaceRoom ? PowerLevel.Admin : PowerLevel.Default,
+        [EventType.Reaction]: isSpace ? PowerLevel.Admin : PowerLevel.Default,
+        [EventType.RoomRedaction]: isSpace ? PowerLevel.Admin : PowerLevel.Default,
 
         // MSC3401: Native Group VoIP signaling
         [ElementCall.CALL_EVENT_TYPE.name]: PowerLevel.Moderator,
@@ -134,17 +138,17 @@ export function getEventPowerLevelOpts(
     eventType: string,
     roomType: RoomType | string,
 ): EventPowerLevelOpts | EventPowerLevelOptsMap {
-    const isSpaceRoom = roomType === RoomType.Space;
+    const isSpace = isSpaceRoom(roomType);
 
     const eventPowerLevelLabels: EventPowerLevelOptsMap = {
         [EventType.RoomAvatar]: {
-            label: isSpaceRoom ? _t("Change space avatar") : _t("Change room avatar"),
+            label: isSpace ? _t("Change space avatar") : _t("Change room avatar"),
         },
         [EventType.RoomName]: {
-            label: isSpaceRoom ? _t("Change space name") : _t("Change room name"),
+            label: isSpace ? _t("Change space name") : _t("Change room name"),
         },
         [EventType.RoomCanonicalAlias]: {
-            label: isSpaceRoom ? _t("Change main address for the space") : _t("Change main address for the room"),
+            label: isSpace ? _t("Change main address for the space") : _t("Change main address for the room"),
         },
         [EventType.SpaceChild]: {
             label: _t("Manage rooms in this space"),
@@ -156,7 +160,7 @@ export function getEventPowerLevelOpts(
             label: _t("Change permissions"),
         },
         [EventType.RoomTopic]: {
-            label: isSpaceRoom ? _t("Change description") : _t("Change topic"),
+            label: isSpace ? _t("Change description") : _t("Change topic"),
         },
         [EventType.RoomTombstone]: {
             label: _t("Upgrade the room"),
@@ -180,7 +184,7 @@ export function getEventPowerLevelOpts(
 
         // TODO: Enable support for m.widget event type (https://github.com/vector-im/element-web/issues/13111)
         "im.vector.modular.widgets": {
-            label: isSpaceRoom ? null : _t("Modify widgets"),
+            label: isSpace ? null : _t("Modify widgets"),
         },
         [VoiceBroadcastInfoEventType]: {
             label: _t("Voice broadcasts"),
@@ -199,4 +203,9 @@ export function getEventPowerLevelsDescriptors(roomType: RoomType | string): Eve
         };
     });
     return eventPowerLevelsDescriptors;
+}
+
+// 通过是否允许普通用户发送信息来计算events_default的值
+export function getEventsDefaultByEnableDefaultUserSendMsg(enableDefaultUserSendMsg: boolean): PowerLevel {
+    return enableDefaultUserSendMsg ? PowerLevel.Default : PowerLevel.Moderator;
 }

--- a/src/matrix-react-sdk/src/powerLevel.ts
+++ b/src/matrix-react-sdk/src/powerLevel.ts
@@ -61,6 +61,7 @@ export function getDefaultPowerLevels(roomType: RoomType | string, joinRule: Joi
         kick: PowerLevel.Moderator,
         ban: PowerLevel.Moderator,
         redact: PowerLevel.Moderator,
+        display_member_list: PowerLevel.Default, // 哪些角色可以展示成员列表
         // "notifications.room": PowerLevel.Moderator,
     };
 }
@@ -89,6 +90,9 @@ export function getPowerLevelOpts(eventType: string): PowerLevelOpts | PowerLeve
         },
         "notifications.room": {
             label: _t("Notify everyone"),
+        },
+        display_member_list: {
+            label: "展示成员列表",
         },
     };
 
@@ -205,7 +209,16 @@ export function getEventPowerLevelsDescriptors(roomType: RoomType | string): Eve
     return eventPowerLevelsDescriptors;
 }
 
-// 通过是否允许普通用户发送信息来计算events_default的值
-export function getEventsDefaultByEnableDefaultUserSendMsg(enableDefaultUserSendMsg: boolean): PowerLevel {
-    return enableDefaultUserSendMsg ? PowerLevel.Default : PowerLevel.Moderator;
+// 通过是否允许普通用户发送信息来计算events_default（是否可以发送消息）的值
+export function getPowerLevelByEnableDefaultUserSendMsg(enableDefaultUserSendMsg: boolean): PowerLevelsMap {
+    return {
+        events_default: enableDefaultUserSendMsg ? PowerLevel.Default : PowerLevel.Moderator,
+    };
+}
+
+// 通过是否允许普通用户展示成员列表信息来计算display_member_list（是否展示成员列表）的值
+export function getPowerLevelByEnableDefaultUserMemberList(enableDefaultUserMemberList: boolean): PowerLevelsMap {
+    return {
+        display_member_list: enableDefaultUserMemberList ? PowerLevel.Default : PowerLevel.Moderator,
+    };
 }

--- a/src/matrix-react-sdk/src/powerLevel.ts
+++ b/src/matrix-react-sdk/src/powerLevel.ts
@@ -1,0 +1,202 @@
+import { EventType, RoomType } from "matrix-js-sdk/src/@types/event";
+import { JoinRule } from "matrix-js-sdk/src/@types/partials";
+import { isPrivateRoom } from "../../vector/rewrite-js-sdk/room";
+import { _t, _td } from "matrix-react-sdk/src/languageHandler";
+import { ElementCall } from "matrix-react-sdk/src/models/Call";
+import { VoiceBroadcastInfoEventType } from "matrix-react-sdk/src/voice-broadcast";
+
+export enum PowerLevel {
+    Admin = 100, // 管理员
+    Moderator = 50, // 协管员
+    Default = 0, // 普通用户
+}
+export const PowerLabel: Record<PowerLevel, string> = {
+    [PowerLevel.Admin]: _td("Admin"),
+    [PowerLevel.Moderator]: _td("Mod"),
+    [PowerLevel.Default]: _td("Default"),
+};
+
+interface PowerLevelsMap {
+    [type: string]: PowerLevel;
+}
+
+interface PowerLevelDescriptorItem {
+    label: string;
+    defaultValue: PowerLevel;
+}
+
+type PowerLevelOpts = Omit<PowerLevelDescriptorItem, "defaultValue">;
+interface PowerLevelOptsMap {
+    [eventType: string]: PowerLevelOpts;
+}
+interface PowerLevelDescriptorMap {
+    [eventType: string]: PowerLevelDescriptorItem;
+}
+
+interface EventPowerLevelDescriptorItem {
+    label: string;
+    defaultValue: PowerLevel;
+}
+
+type EventPowerLevelOpts = Omit<EventPowerLevelDescriptorItem, "defaultValue">;
+interface EventPowerLevelOptsMap {
+    [eventType: string]: EventPowerLevelOpts;
+}
+interface EventPowerLevelDescriptorsMap {
+    [eventType: string]: EventPowerLevelDescriptorItem;
+}
+
+// state powerLevel
+export function getDefaultPowerLevels(roomType: RoomType | string, joinRule: JoinRule): PowerLevelsMap {
+    const isSpaceRoom = roomType === RoomType.Space;
+    return {
+        users_default: PowerLevel.Default,
+        state_default: PowerLevel.Moderator,
+        events_default: isSpaceRoom ? PowerLevel.Admin : PowerLevel.Default, // 哪些角色可以发送消息
+        invite: isSpaceRoom && isPrivateRoom(joinRule) ? PowerLevel.Moderator : PowerLevel.Default, // 私密社区协管员及以上权限才可以邀请
+        kick: PowerLevel.Moderator,
+        ban: PowerLevel.Moderator,
+        redact: PowerLevel.Moderator,
+        // "notifications.room": PowerLevel.Moderator,
+    };
+}
+export function getPowerLevelOpts(eventType: string): PowerLevelOpts | PowerLevelOptsMap {
+    const eventPowerLevelLabels: PowerLevelOptsMap = {
+        users_default: {
+            label: _t("Default role"),
+        },
+        events_default: {
+            label: _t("Send messages"),
+        },
+        invite: {
+            label: _t("Invite users"),
+        },
+        state_default: {
+            label: _t("Change settings"),
+        },
+        kick: {
+            label: _t("Remove users"),
+        },
+        ban: {
+            label: _t("Ban users"),
+        },
+        redact: {
+            label: _t("Remove messages sent by others"),
+        },
+        "notifications.room": {
+            label: _t("Notify everyone"),
+        },
+    };
+
+    return eventType ? eventPowerLevelLabels[eventType] : eventPowerLevelLabels;
+}
+export function getPowerLevelsDescriptors(roomType: RoomType | string, joinRule): PowerLevelDescriptorMap {
+    const powerLevels = getDefaultPowerLevels(roomType, joinRule);
+    const eventPowerLevelsDescriptors = {};
+    Object.keys(powerLevels).forEach((eventType) => {
+        eventPowerLevelsDescriptors[eventType] = {
+            ...getPowerLevelOpts(eventType),
+            defaultValue: powerLevels[eventType],
+        };
+    });
+    return eventPowerLevelsDescriptors;
+}
+
+// event powerLevel
+export function getDefaultEventPowerLevels(roomType: RoomType | string): PowerLevelsMap {
+    const isSpaceRoom = roomType === RoomType.Space;
+
+    return {
+        [EventType.RoomAvatar]: PowerLevel.Moderator,
+        [EventType.RoomTopic]: PowerLevel.Moderator,
+        [EventType.RoomName]: PowerLevel.Moderator,
+        [EventType.RoomCanonicalAlias]: PowerLevel.Moderator,
+        [EventType.SpaceChild]: PowerLevel.Moderator,
+        [EventType.RoomPinnedEvents]: PowerLevel.Moderator,
+        [EventType.RoomHistoryVisibility]: PowerLevel.Admin,
+        [EventType.RoomPowerLevels]: PowerLevel.Admin,
+        [EventType.RoomTombstone]: PowerLevel.Admin,
+        [EventType.RoomEncryption]: PowerLevel.Admin,
+        [EventType.RoomServerAcl]: PowerLevel.Admin,
+        [EventType.Reaction]: isSpaceRoom ? PowerLevel.Admin : PowerLevel.Default,
+        [EventType.RoomRedaction]: isSpaceRoom ? PowerLevel.Admin : PowerLevel.Default,
+
+        // MSC3401: Native Group VoIP signaling
+        [ElementCall.CALL_EVENT_TYPE.name]: PowerLevel.Moderator,
+        [ElementCall.MEMBER_EVENT_TYPE.name]: PowerLevel.Moderator,
+
+        // TODO: Enable support for m.widget event type (https://github.com/vector-im/element-web/issues/13111)
+        "im.vector.modular.widgets": PowerLevel.Moderator,
+        [VoiceBroadcastInfoEventType]: PowerLevel.Moderator,
+    };
+}
+export function getEventPowerLevelOpts(
+    eventType: string,
+    roomType: RoomType | string,
+): EventPowerLevelOpts | EventPowerLevelOptsMap {
+    const isSpaceRoom = roomType === RoomType.Space;
+
+    const eventPowerLevelLabels: EventPowerLevelOptsMap = {
+        [EventType.RoomAvatar]: {
+            label: isSpaceRoom ? _t("Change space avatar") : _t("Change room avatar"),
+        },
+        [EventType.RoomName]: {
+            label: isSpaceRoom ? _t("Change space name") : _t("Change room name"),
+        },
+        [EventType.RoomCanonicalAlias]: {
+            label: isSpaceRoom ? _t("Change main address for the space") : _t("Change main address for the room"),
+        },
+        [EventType.SpaceChild]: {
+            label: _t("Manage rooms in this space"),
+        },
+        [EventType.RoomHistoryVisibility]: {
+            label: _t("Change history visibility"),
+        },
+        [EventType.RoomPowerLevels]: {
+            label: _t("Change permissions"),
+        },
+        [EventType.RoomTopic]: {
+            label: isSpaceRoom ? _t("Change description") : _t("Change topic"),
+        },
+        [EventType.RoomTombstone]: {
+            label: _t("Upgrade the room"),
+        },
+        [EventType.RoomEncryption]: {
+            label: _t("Enable room encryption"),
+        },
+        [EventType.RoomServerAcl]: {
+            label: _t("Change server ACLs"),
+        },
+        [EventType.Reaction]: {
+            label: _t("Send reactions"),
+        },
+        [EventType.RoomRedaction]: {
+            label: _t("Remove messages sent by me"),
+        },
+
+        [EventType.RoomPinnedEvents]: {
+            label: _t("Manage pinned events"),
+        },
+
+        // TODO: Enable support for m.widget event type (https://github.com/vector-im/element-web/issues/13111)
+        "im.vector.modular.widgets": {
+            label: isSpaceRoom ? null : _t("Modify widgets"),
+        },
+        [VoiceBroadcastInfoEventType]: {
+            label: _t("Voice broadcasts"),
+        },
+    };
+
+    return eventType ? eventPowerLevelLabels[eventType] : eventPowerLevelLabels;
+}
+export function getEventPowerLevelsDescriptors(roomType: RoomType | string): EventPowerLevelDescriptorsMap {
+    const eventPowerLevels = getDefaultEventPowerLevels(roomType);
+    const eventPowerLevelsDescriptors = {};
+    Object.keys(eventPowerLevels).forEach((eventType) => {
+        eventPowerLevelsDescriptors[eventType] = {
+            label: getEventPowerLevelOpts(eventType, roomType),
+            defaultValue: eventPowerLevels[eventType],
+        };
+    });
+    return eventPowerLevelsDescriptors;
+}

--- a/src/matrix-react-sdk/src/powerLevel.ts
+++ b/src/matrix-react-sdk/src/powerLevel.ts
@@ -56,6 +56,8 @@ export function isSpaceRoom(roomType: RoomType | string): boolean {
     return roomType === RoomType.Space;
 }
 
+export const DefaultPowerLevelToManageSpacePrivateChannel = PowerLevel.Moderator;
+
 // state powerLevel
 export function getDefaultStatePowerLevels(roomType: RoomType | string, joinRule: JoinRule): PowerLevelsMap {
     const isSpace = isSpaceRoom(roomType);
@@ -68,6 +70,7 @@ export function getDefaultStatePowerLevels(roomType: RoomType | string, joinRule
         ban: PowerLevel.Moderator,
         redact: PowerLevel.Moderator,
         display_member_list: isSpace ? PowerLevel.Moderator : PowerLevel.Default, // 哪些角色可以展示成员列表
+        ...(isSpace ? { manage_space_private_channel: DefaultPowerLevelToManageSpacePrivateChannel } : {}), // 哪些角色可以管理社区内的私密频道
         // "notifications.room": PowerLevel.Moderator,
     };
 }

--- a/src/matrix-react-sdk/src/powerLevel.ts
+++ b/src/matrix-react-sdk/src/powerLevel.ts
@@ -16,6 +16,12 @@ export const PowerLabel: Record<PowerLevel, string> = {
     [PowerLevel.Default]: _td("Default"),
 };
 
+interface InitPowerLevelsParams {
+    isSpace?: boolean;
+    enableDefaultUserSendMsg?: boolean;
+    enableDefaultUserMemberList?: boolean;
+}
+
 interface PowerLevelsMap {
     [type: string]: PowerLevel;
 }
@@ -210,15 +216,31 @@ export function getEventPowerLevelsDescriptors(roomType: RoomType | string): Eve
 }
 
 // 通过是否允许普通用户发送信息来计算events_default（是否可以发送消息）的值
-export function getPowerLevelByEnableDefaultUserSendMsg(enableDefaultUserSendMsg: boolean): PowerLevelsMap {
-    return {
-        events_default: enableDefaultUserSendMsg ? PowerLevel.Default : PowerLevel.Moderator,
-    };
+export function getPowerLevelByEnableDefaultUserSendMsg(enable: boolean, isSpace = false): PowerLevelsMap {
+    return !isSpace
+        ? {
+              events_default: enable ? PowerLevel.Default : PowerLevel.Moderator,
+          }
+        : {};
 }
 
 // 通过是否允许普通用户展示成员列表信息来计算display_member_list（是否展示成员列表）的值
-export function getPowerLevelByEnableDefaultUserMemberList(enableDefaultUserMemberList: boolean): PowerLevelsMap {
+export function getPowerLevelByEnableDefaultUserMemberList(enable: boolean, isSpace = false): PowerLevelsMap {
+    return !isSpace
+        ? {
+              display_member_list: enable ? PowerLevel.Default : PowerLevel.Moderator,
+          }
+        : {};
+}
+
+// 获取初始化powerLevels
+export function getInitStatePowerLevels({
+    isSpace = false,
+    enableDefaultUserSendMsg,
+    enableDefaultUserMemberList,
+}: InitPowerLevelsParams): PowerLevelsMap {
     return {
-        display_member_list: enableDefaultUserMemberList ? PowerLevel.Default : PowerLevel.Moderator,
+        ...getPowerLevelByEnableDefaultUserSendMsg(enableDefaultUserSendMsg, isSpace),
+        ...getPowerLevelByEnableDefaultUserMemberList(enableDefaultUserMemberList, isSpace),
     };
 }

--- a/src/matrix-react-sdk/src/powerLevel.ts
+++ b/src/matrix-react-sdk/src/powerLevel.ts
@@ -218,7 +218,7 @@ export function getEventPowerLevelsDescriptors(roomType: RoomType | string): Eve
     return eventPowerLevelsDescriptors;
 }
 
-// 通过是否允许普通用户发送信息来计算events_default（是否可以发送消息）的值
+// 通过启用|禁用允许普通用户发送消息来计算events_default（是否可以发送消息）的powerLevel值
 export function getPowerLevelByEnableDefaultUserSendMsg(enable: boolean, isSpace = false): PowerLevelsMap {
     return !isSpace
         ? {
@@ -227,7 +227,7 @@ export function getPowerLevelByEnableDefaultUserSendMsg(enable: boolean, isSpace
         : {};
 }
 
-// 通过是否允许普通用户展示成员列表信息来计算display_member_list（是否展示成员列表）的值
+// 通过启用|禁用允许普通用户展示成员列表来计算display_member_list（是否展示成员列表）的powerLevel值
 export function getPowerLevelByEnableDefaultUserMemberList(enable: boolean, isSpace = false): PowerLevelsMap {
     return !isSpace
         ? {

--- a/src/matrix-react-sdk/src/powerLevel.ts
+++ b/src/matrix-react-sdk/src/powerLevel.ts
@@ -51,7 +51,7 @@ export function isSpaceRoom(roomType: RoomType | string): boolean {
 }
 
 // state powerLevel
-export function getDefaultPowerLevels(roomType: RoomType | string, joinRule: JoinRule): PowerLevelsMap {
+export function getDefaultStatePowerLevels(roomType: RoomType | string, joinRule: JoinRule): PowerLevelsMap {
     const isSpace = isSpaceRoom(roomType);
     return {
         users_default: PowerLevel.Default,
@@ -61,7 +61,7 @@ export function getDefaultPowerLevels(roomType: RoomType | string, joinRule: Joi
         kick: PowerLevel.Moderator,
         ban: PowerLevel.Moderator,
         redact: PowerLevel.Moderator,
-        display_member_list: PowerLevel.Default, // 哪些角色可以展示成员列表
+        display_member_list: isSpace ? PowerLevel.Moderator : PowerLevel.Default, // 哪些角色可以展示成员列表
         // "notifications.room": PowerLevel.Moderator,
     };
 }
@@ -99,7 +99,7 @@ export function getPowerLevelOpts(eventType: string): PowerLevelOpts | PowerLeve
     return eventType ? eventPowerLevelLabels[eventType] : eventPowerLevelLabels;
 }
 export function getPowerLevelsDescriptors(roomType: RoomType | string, joinRule): PowerLevelDescriptorMap {
-    const powerLevels = getDefaultPowerLevels(roomType, joinRule);
+    const powerLevels = getDefaultStatePowerLevels(roomType, joinRule);
     const eventPowerLevelsDescriptors = {};
     Object.keys(powerLevels).forEach((eventType) => {
         eventPowerLevelsDescriptors[eventType] = {

--- a/src/matrix-react-sdk/src/stores/spaces/index.ts
+++ b/src/matrix-react-sdk/src/stores/spaces/index.ts
@@ -28,6 +28,8 @@ export const UPDATE_SELECTED_SPACE = Symbol("selected-space");
 export const UPDATE_HOME_BEHAVIOUR = Symbol("home-behaviour");
 export const UPDATE_SUGGESTED_ROOMS = Symbol("suggested-rooms");
 
+export const UPDATE_FILTERED_SUGGESTED_ROOMS = Symbol("filtered-suggested-rooms");
+
 export const UPDATE_SPACE_TAGS = Symbol("space-tags");
 // Space Key will be emitted when a Space's children change
 
@@ -52,10 +54,9 @@ export const getMetaSpaceName = (spaceKey: MetaSpace, allRoomsInHome = false): s
 };
 
 export type SpaceKey = MetaSpace | Room["roomId"];
-
 export interface ISuggestedRoom extends IHierarchyRoom {
     viaServers: string[];
-    join_rule: JoinRule;
+    join_rule?: JoinRule;
 }
 
 export function isMetaSpace(spaceKey?: SpaceKey): boolean {

--- a/src/matrix-react-sdk/src/utils/EventUtils.ts
+++ b/src/matrix-react-sdk/src/utils/EventUtils.ts
@@ -45,6 +45,8 @@ export const displayEventType = [
     EventType.RoomMessage,
 ];
 
+export const hiddenEventTypeIfNotDisplayMemberList = [EventType.RoomMember]; // 不展示成员列表时需要隐藏的事件类型
+
 /**
  * Returns whether an event should allow actions like reply, reactions, edit, etc.
  * which effectively checks whether it's a regular message that has been sent and that we

--- a/src/matrix-react-sdk/src/utils/MultiInviter.ts
+++ b/src/matrix-react-sdk/src/utils/MultiInviter.ts
@@ -148,7 +148,7 @@ export default class MultiInviter {
         return this.errors[addr]?.errorText ?? null;
     }
 
-    private async inviteToRoom(roomId: string, addr: string, ignoreProfile = false): Promise<{}> {
+    private async inviteToRoom(roomId: string, addr: string, ignoreProfile = false): Promise<{} | void> {
         const addrType = getAddressType(addr);
 
         if (addrType === AddressType.Email) {
@@ -157,7 +157,11 @@ export default class MultiInviter {
             const room = this.matrixClient.getRoom(roomId);
             if (!room) throw new Error("Room not found");
 
-            // const member = room.getMember(addr);
+            // 已加入或者已发送邀请的用户当做邀请成功处理
+            const member = room.getMember(addr);
+            if (["invite", "join"].includes(member?.membership)) {
+                return Promise.resolve();
+            }
             // if (member?.membership === "join") {
             //     throw new MatrixError({
             //         errcode: USER_ALREADY_JOINED,

--- a/src/vector/rewrite-js-sdk/room-member.ts
+++ b/src/vector/rewrite-js-sdk/room-member.ts
@@ -3,7 +3,7 @@ import { removeDirectionOverrideChars, removeHiddenChars } from "matrix-js-sdk/s
 import OrgStore from "matrix-react-sdk/src/stores/OrgStore";
 import { MatrixEvent } from "matrix-js-sdk/src/models/event";
 import { RoomState } from "matrix-js-sdk/src/models/room-state";
-import { PowerLevel } from "../../matrix-react-sdk/src/components/views/rooms/EntityTile";
+import { PowerLevel } from "matrix-react-sdk/src/powerLevel";
 
 const powerLevels = [PowerLevel.Admin, PowerLevel.Moderator];
 

--- a/src/vector/rewrite-js-sdk/room.ts
+++ b/src/vector/rewrite-js-sdk/room.ts
@@ -6,6 +6,7 @@ import { EventType } from "matrix-js-sdk/src/@types/event";
 import { PreferredRoomVersions } from "matrix-react-sdk/src/utils/PreferredRoomVersions";
 import { JoinRule } from "matrix-js-sdk/src/@types/partials";
 import SpaceStore from "matrix-react-sdk/src/stores/spaces/SpaceStore";
+import { PowerLevel } from "matrix-react-sdk/src/powerLevel";
 
 export enum RoomType {
     People = "people", // 私聊
@@ -123,6 +124,19 @@ Room.prototype.canRemoveUser = function (userId: string) {
     const powerLevels = powerLevelsEvent && powerLevelsEvent.getContent();
     const me = this.getMember(userId);
     return powerLevels && me && me.powerLevel >= powerLevels.kick;
+};
+
+// 判断是否展示成员列表
+Room.prototype.displayMemberList = function (userId: string) {
+    if (this.getMyMembership() !== "join") {
+        return false;
+    }
+
+    const powerLevelsEvent = this.currentState.getStateEvents(EventType.RoomPowerLevels, "");
+    const powerLevelContent = powerLevelsEvent && powerLevelsEvent.getContent();
+    const { display_member_list = PowerLevel.Default } = powerLevelContent ?? {};
+    const me = this.getMember(userId);
+    return me && me.powerLevel >= display_member_list;
 };
 
 // 判断是否可以增删改Tag


### PR DESCRIPTION
1. 社区首页频道列表优化，数据源和左侧频道列表保持一致
2. 建议的频道只加载一页bugfix
3. 特权用户建议的频道分组下展示私密频道 & 私密频道新增邀请功能
4. 历史消息可读性修改：群聊从用户被邀请后的消息可读；社区内的频道默认历史消息可读
5. 切换社区可见性时，修改powerLevel
6. 新增“是否允许普通用户发送消息”配置项
7.  新增“是否允许普通用户展示成员列表”配置项