### PR TITLE
hos#136 app端适配

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,13 @@ ipfs服务          http://127.0.0.1:xxx/?origin=https://ipfs.system.service.hel
 
 
 ## 本地开发
-
-本地开发有两种模式可以选择
+本地开发有三种模式可以选择
 1. 客户端模式【默认】（和客户端处理请求的逻辑保持一致）
 2. web网页端模式（和web网页端处理请求的逻辑保持一致）
+3. app端模式（和app网页端处理请求的逻辑保持一致）
 
 >**Note**:<br>
 > 可以在 src/matrix-react-sdk/src/utils/env.ts 中更改 devModel 变量，切换本地开发模式
+> 本地开发三种模式相关代理配置可在 config/config.heliumos.ts 中查看
+> 本地开发模式选择客户端模式时，需要在浏览器中使用代理设置工具【如switchyOmega】配置本地代理，因为matrix服务和ipfs服务在 config/config.heliumos.ts 中没有配置代理，直接请求的原始地址，其余两种模式则不需要
 

--- a/README.md
+++ b/README.md
@@ -38,5 +38,6 @@ ipfs服务          http://127.0.0.1:xxx/?origin=https://ipfs.system.service.hel
 >**Note**:<br>
 > 可以在 src/matrix-react-sdk/src/utils/env.ts 中更改 devModel 变量，切换本地开发模式
 > 本地开发三种模式相关代理配置可在 config/config.heliumos.ts 中查看
+> 以上两点在本地开发时需要配合使用
 > 本地开发模式选择客户端模式时，需要在浏览器中使用代理设置工具【如switchyOmega】配置本地代理，因为matrix服务和ipfs服务在 config/config.heliumos.ts 中没有配置代理，直接请求的原始地址，其余两种模式则不需要
 

--- a/config/config.heliumos.ts
+++ b/config/config.heliumos.ts
@@ -1,5 +1,14 @@
 const { HttpsProxyAgent } = require("https-proxy-agent");
-const agent = new HttpsProxyAgent("http://127.0.0.1:53496"); // 端口号是起desktop后，proxy随机生成的port
+
+/**
+ * 端口号是通过调用runProxy所起的本地node服务端口号
+ * 如果当前开发模式为App模式，端口号为本地heliumos-app项目所起的公共服务端口号
+ * 如果当前开发模式为Destkop模式，端口号为本地heliumos-client-desktop项目所起的node服务端口号
+ * 如果当前开发模式为Website模式，端口号以上两种都可以
+ */
+const target = "http://127.0.0.1:56236";
+
+const agent = new HttpsProxyAgent(target);
 
 module.exports = {
     define: {
@@ -57,6 +66,14 @@ module.exports = {
                 "^/web/ipfs": "/ipfs",
             },
             agent,
+        },
+
+        // 本地开发app端代理，方便本地调试【测试环境和生产环境不需要相关nginx配置】
+        "/app": {
+            target,
+            changeOrigin: true,
+            secure: false,
+            pathRewrite: { "^/app": "" },
         },
     },
 };

--- a/src/matrix-react-sdk/res/css/_common.pcss
+++ b/src/matrix-react-sdk/res/css/_common.pcss
@@ -308,7 +308,7 @@ legend {
         }
     }
     &.mx_Dialog_inApp:not(.mx_Dialog_fullScreen) {
-        max-width: 90%;
+        width: 90%;
         .mx_Dialog_fixedWidth {
             width: 100%;
             max-width: unset;

--- a/src/matrix-react-sdk/res/css/_common.pcss
+++ b/src/matrix-react-sdk/res/css/_common.pcss
@@ -307,7 +307,10 @@ legend {
             max-height: unset;
         }
     }
-    &.mx_Dialog_inApp:not(.mx_Dialog_fullScreen) {
+    .mx_Dialog_autoWidth {
+        width: auto;
+    }
+    &.mx_Dialog_inApp:not(.mx_Dialog_fullScreen):not(.mx_Dialog_autoWidth) {
         width: 90%;
         .mx_Dialog_fixedWidth {
             width: 100%;

--- a/src/matrix-react-sdk/res/css/structures/_HomePage.pcss
+++ b/src/matrix-react-sdk/res/css/structures/_HomePage.pcss
@@ -25,11 +25,20 @@ limitations under the License.
 }
 
 .mx_HomePage_default {
-    text-align: center;
+    position: relative;
     display: flex;
+    align-items: center;
+
+    .mx_RoomViewHeader_back {
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 60px;
+    }
 
     .mx_HomePage_default_wrapper {
-        margin: auto;
+        flex: 1;
+        overflow: hidden;
         text-align: center;
     }
 
@@ -58,6 +67,7 @@ limitations under the License.
 
     .mx_HomePage_actionWrap {
         display: flex;
+        justify-content: center;
         margin: 20px auto 0;
         gap: 60px;
         .mx_HomePage_actionItem {
@@ -89,6 +99,12 @@ limitations under the License.
         }
         .mx_HomePage_actionBtn {
             margin-top: 30px;
+        }
+    }
+
+    &.inApp {
+        .mx_HomePage_actionWrap {
+            gap: 10px;
         }
     }
 }

--- a/src/matrix-react-sdk/res/css/structures/_RoomView.pcss
+++ b/src/matrix-react-sdk/res/css/structures/_RoomView.pcss
@@ -30,6 +30,13 @@ limitations under the License.
     contain: strict;
 }
 
+
+.mx_RoomViewHeader_back {
+    width: 60px;
+    height: 100%;
+    @mixin MaskIcon url("$(res)/img/back.svg"), 16px, 20px, #000000;
+}
+
 .mx_RoomView {
     word-wrap: break-word;
     display: flex;

--- a/src/matrix-react-sdk/res/css/structures/_SpaceHierarchy.pcss
+++ b/src/matrix-react-sdk/res/css/structures/_SpaceHierarchy.pcss
@@ -178,4 +178,12 @@ limitations under the License.
         margin: 16px auto 0;
         width: max-content;
     }
+
+
+
+    &.inApp {
+        .mx_SpaceHierarchy_header {
+            padding-left: 0;
+        }
+    }
 }

--- a/src/matrix-react-sdk/res/css/views/dialogs/_ForwardDialog.pcss
+++ b/src/matrix-react-sdk/res/css/views/dialogs/_ForwardDialog.pcss
@@ -77,6 +77,10 @@ limitations under the License.
             max-width: 40%;
         }
     }
+
+    &.inApp {
+        width: 100%;
+    }
 }
 
 .mx_ForwardList_entry {

--- a/src/matrix-react-sdk/res/css/views/dialogs/security/_CreateSecretStorageDialog.pcss
+++ b/src/matrix-react-sdk/res/css/views/dialogs/security/_CreateSecretStorageDialog.pcss
@@ -15,6 +15,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+.mx_Dialog_CreateSecretStorage .mx_Dialog_inApp{
+    width: unset!important;
+}
+
 .mx_CreateSecretStorageDialog {
     /* Why you ask? Because CompleteSecurityBody is 600px so this is the width */
     /* we end up when in there, but when in our own dialog we set our own width */

--- a/src/matrix-react-sdk/res/css/views/dialogs/security/_CreateSecretStorageDialog.pcss
+++ b/src/matrix-react-sdk/res/css/views/dialogs/security/_CreateSecretStorageDialog.pcss
@@ -15,10 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_Dialog_CreateSecretStorage .mx_Dialog_inApp{
-    width: unset!important;
-}
-
 .mx_CreateSecretStorageDialog {
     /* Why you ask? Because CompleteSecurityBody is 600px so this is the width */
     /* we end up when in there, but when in our own dialog we set our own width */

--- a/src/matrix-react-sdk/res/css/views/rooms/_RoomHeader.pcss
+++ b/src/matrix-react-sdk/res/css/views/rooms/_RoomHeader.pcss
@@ -58,12 +58,6 @@ limitations under the License.
     }
 }
 
-.mx_RoomHeader_back {
-    width: 60px;
-    height: 100%;
-    @mixin MaskIcon url("$(res)/img/back.svg"), 16px, 20px, #000000;
-}
-
 .mx_RoomHeader_spinner {
     flex: 1;
     height: 36px;

--- a/src/matrix-react-sdk/src/Lifecycle.ts
+++ b/src/matrix-react-sdk/src/Lifecycle.ts
@@ -659,9 +659,7 @@ async function doSetLoggedIn(credentials: IMatrixClientCreds, clearStorageEnable
         logger.warn("No local storage available: can't persist session!");
     }
 
-    try {
-        await setOrgList();
-    } catch (error) {}
+    setOrgList();
 
     console.log("init bugfix dispatch Action.OnLoggedIn");
     dis.fire(Action.OnLoggedIn);

--- a/src/matrix-react-sdk/src/Modal.tsx
+++ b/src/matrix-react-sdk/src/Modal.tsx
@@ -51,7 +51,8 @@ export type ComponentProps<C extends ComponentType> = Defaultize<
 export interface IModal<C extends ComponentType> {
     elem: React.ReactNode;
     className?: string;
-    fullScreen?: boolean;
+    fullScreen?: boolean; // Modal是否全屏展示
+    autoWidth?: boolean; // Modal宽度是否自适应
     beforeClosePromise?: Promise<boolean>;
     closeReason?: string;
     onBeforeClose?(reason?: string): Promise<boolean>;
@@ -67,7 +68,8 @@ export interface IHandle<C extends ComponentType> {
 
 interface IOptions<C extends ComponentType> {
     onBeforeClose?: IModal<C>["onBeforeClose"];
-    fullScreen?: boolean;
+    fullScreen?: boolean; // Modal是否全屏展示
+    autoWidth?: boolean; // Modal宽度是否自适应
 }
 
 export enum ModalManagerEvent {
@@ -182,6 +184,7 @@ export class ModalManager extends TypedEventEmitter<ModalManagerEvent, HandlerMa
             className,
 
             fullScreen: options?.fullScreen,
+            autoWidth: options?.autoWidth,
             // these will be set below but we need an object reference to pass to getCloseFn before we can do that
             elem: null,
         } as IModal<C>;
@@ -384,9 +387,9 @@ export class ModalManager extends TypedEventEmitter<ModalManagerEvent, HandlerMa
             const staticDialog = (
                 <div className={classes}>
                     <div
-                        className={`mx_Dialog ${this.staticModal.fullScreen ? "mx_Dialog_fullScreen" : ""} ${
-                            isInApp ? "mx_Dialog_inApp" : ""
-                        }`}
+                        className={`mx_Dialog ${this.staticModal.autoWidth ? "mx_Dialog_autoWidth" : ""} ${
+                            this.staticModal.fullScreen ? "mx_Dialog_fullScreen" : ""
+                        } ${isInApp ? "mx_Dialog_inApp" : ""}`}
                     >
                         {this.staticModal.elem}
                     </div>
@@ -413,9 +416,9 @@ export class ModalManager extends TypedEventEmitter<ModalManagerEvent, HandlerMa
             const dialog = (
                 <div className={classes}>
                     <div
-                        className={`mx_Dialog ${modal.fullScreen ? "mx_Dialog_fullScreen" : ""} ${
-                            isInApp ? "mx_Dialog_inApp" : ""
-                        }`}
+                        className={`mx_Dialog ${modal.autoWidth ? "mx_Dialog_autoWidth" : ""} ${
+                            modal.fullScreen ? "mx_Dialog_fullScreen" : ""
+                        } ${isInApp ? "mx_Dialog_inApp" : ""}`}
                     >
                         {modal.elem}
                     </div>

--- a/src/matrix-react-sdk/src/SecurityManager.ts
+++ b/src/matrix-react-sdk/src/SecurityManager.ts
@@ -159,6 +159,7 @@ async function getSecretStorageKey({
         /* isPriorityModal= */ false,
         /* isStaticModal= */ false,
         /* options= */ {
+            autoWidth: true,
             onBeforeClose: async (reason): Promise<boolean> => {
                 if (reason === "backgroundClick") {
                     return confirmToDismiss();
@@ -209,6 +210,7 @@ export async function getDehydrationKey(
         /* isPriorityModal= */ false,
         /* isStaticModal= */ false,
         /* options= */ {
+            autoWidth: true,
             onBeforeClose: async (reason): Promise<boolean> => {
                 if (reason === "backgroundClick") {
                     return confirmToDismiss();
@@ -337,10 +339,11 @@ export async function accessSecretStorage(func = async (): Promise<void> => {}, 
                 {
                     forceReset,
                 },
-                "mx_Dialog_CreateSecretStorage",
+                undefined,
                 /* priority = */ false,
                 /* static = */ true,
                 /* options = */ {
+                    autoWidth: true,
                     onBeforeClose: async (reason): Promise<boolean> => {
                         // If Secure Backup is required, you cannot leave the modal.
                         if (reason === "backgroundClick") {

--- a/src/matrix-react-sdk/src/SecurityManager.ts
+++ b/src/matrix-react-sdk/src/SecurityManager.ts
@@ -337,7 +337,7 @@ export async function accessSecretStorage(func = async (): Promise<void> => {}, 
                 {
                     forceReset,
                 },
-                undefined,
+                "mx_Dialog_CreateSecretStorage",
                 /* priority = */ false,
                 /* static = */ true,
                 /* options = */ {

--- a/src/matrix-react-sdk/src/components/structures/HomePage.tsx
+++ b/src/matrix-react-sdk/src/components/structures/HomePage.tsx
@@ -33,6 +33,8 @@ import EmbeddedPage from "./EmbeddedPage";
 import Button, { ButtonType } from "matrix-react-sdk/src/components/views/button/Button";
 import { onCreateRoom } from "matrix-react-sdk/src/components/views/context_menus/SpaceAddChannelContextMenu";
 import SpaceStore from "matrix-react-sdk/src/stores/spaces/SpaceStore";
+import { isInApp } from "matrix-react-sdk/src/utils/env";
+import AppBackLeftPanelBtn from "matrix-react-sdk/src/components/views/elements/AppBackLeftPanelBtn";
 
 const onClickSendDm = (ev: ButtonEvent): void => {
     PosthogTrackers.trackInteraction("WebHomeCreateChatButton", ev);
@@ -83,7 +85,8 @@ const HomePage: React.FC<IProps> = ({ justRegistered = false }) => {
     }
 
     return (
-        <AutoHideScrollbar className="mx_HomePage mx_HomePage_default" element="main">
+        <AutoHideScrollbar className={`mx_HomePage mx_HomePage_default ${isInApp ? "inApp" : ""}`} element="main">
+            <AppBackLeftPanelBtn />
             <div className="mx_HomePage_default_wrapper">
                 <UserWelcomeTop />
                 <div className="mx_HomePage_actionWrap">

--- a/src/matrix-react-sdk/src/components/structures/LeftPanel.tsx
+++ b/src/matrix-react-sdk/src/components/structures/LeftPanel.tsx
@@ -53,7 +53,6 @@ import SpaceAddTagContextMenu from "matrix-react-sdk/src/components/views/contex
 import IconizedContextMenu, {
     IconizedContextMenuOptionList,
 } from "matrix-react-sdk/src/components/views/context_menus/IconizedContextMenu";
-import { isInApp } from "matrix-react-sdk/src/utils/env";
 
 interface IProps {
     isMinimized: boolean;
@@ -453,11 +452,9 @@ export default class LeftPanel extends React.PureComponent<IProps, IState> {
                                 selected={this.props.pageType === PageType.HomePage}
                                 minimized={this.props.isMinimized}
                             />
-                            {!isInApp && (
-                                <div className="mx_LeftPanel_spaceHomeEntrance">
-                                    <SpaceHomeEntrance space={this.state.activeSpace} pageType={this.props.pageType} />
-                                </div>
-                            )}
+                            <div className="mx_LeftPanel_spaceHomeEntrance">
+                                <SpaceHomeEntrance space={this.state.activeSpace} pageType={this.props.pageType} />
+                            </div>
                         </div>
                     </div>
                     <div className="mx_LeftPanel_roomListWrapper">

--- a/src/matrix-react-sdk/src/components/structures/LoggedInView.tsx
+++ b/src/matrix-react-sdk/src/components/structures/LoggedInView.tsx
@@ -204,7 +204,9 @@ class LoggedInView extends React.PureComponent<IProps, IState> {
         } else if (crossSigningPrivateKeysInStorage) {
             // 账户在秘密存储中有交叉签名身份，但并没有被此会话信任，则信任此会话
             console.log("~~~ 账户在秘密存储中有交叉签名身份，但并没有被此会话信任，信任此会话");
-            Modal.createDialog(SetupEncryptionDialog, {}, undefined, /* priority = */ false, /* static = */ true);
+            Modal.createDialog(SetupEncryptionDialog, {}, undefined, /* priority = */ false, /* static = */ true, {
+                autoWidth: true,
+            });
         } else {
             // 未设置交叉签名，则设置备份密钥
             console.log("~~~ 未设置交叉签名，设置备份密钥");

--- a/src/matrix-react-sdk/src/components/structures/MatrixChat.tsx
+++ b/src/matrix-react-sdk/src/components/structures/MatrixChat.tsx
@@ -154,6 +154,7 @@ import User from "matrix-react-sdk/src/utils/User";
 import SpaceStore from "matrix-react-sdk/src/stores/spaces/SpaceStore";
 import defaultDispatcher from "matrix-react-sdk/src/dispatcher/dispatcher";
 import LayoutStore from "matrix-react-sdk/src/stores/LayoutStore";
+import { isInApp } from "matrix-react-sdk/src/utils/env";
 
 // legacy export
 export { default as Views } from "../../Views";
@@ -1729,7 +1730,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
                 showNotificationsToast(false);
             }
 
-            dis.fire(Action.FocusSendMessageComposer);
+            !isInApp && dis.fire(Action.FocusSendMessageComposer);
             this.setState({
                 ready: true,
             });

--- a/src/matrix-react-sdk/src/components/structures/MatrixChat.tsx
+++ b/src/matrix-react-sdk/src/components/structures/MatrixChat.tsx
@@ -479,7 +479,6 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
         window.addEventListener(
             "message",
             (event) => {
-                console.log("Chat window 订阅到message", event.data);
                 this.onReceiveMessage(event);
             },
             false,
@@ -488,7 +487,6 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
         document.addEventListener(
             "message",
             (event) => {
-                console.log("Chat document 订阅到message", event.data);
                 this.onReceiveMessage(event);
             },
             false,

--- a/src/matrix-react-sdk/src/components/structures/MatrixChat.tsx
+++ b/src/matrix-react-sdk/src/components/structures/MatrixChat.tsx
@@ -992,11 +992,12 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
                 }
 
                 // Focus the composer
-                dis.dispatch({
-                    action: Action.FocusSendMessageComposer,
-                    context: TimelineRenderingType.Thread,
-                });
-
+                if (!isInApp) {
+                    dis.dispatch({
+                        action: Action.FocusSendMessageComposer,
+                        context: TimelineRenderingType.Thread,
+                    });
+                }
                 break;
             }
         }
@@ -1043,7 +1044,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
 
     // switch view to the given room
     private async viewRoom(roomInfo: ViewRoomPayload): Promise<void> {
-        this.focusComposer = true;
+        this.focusComposer = !isInApp;
 
         if (roomInfo.room_alias) {
             logger.log(`Switching to room alias ${roomInfo.room_alias} at event ${roomInfo.event_id}`);

--- a/src/matrix-react-sdk/src/components/structures/SpaceHierarchy.tsx
+++ b/src/matrix-react-sdk/src/components/structures/SpaceHierarchy.tsx
@@ -40,6 +40,8 @@ import { DefaultTagID, TagID } from "matrix-react-sdk/src/stores/room-list/model
 import SpaceChannelAvatar from "matrix-react-sdk/src/components/views/avatars/SpaceChannelAvatar";
 import { isPrivateRoom } from "../../../../vector/rewrite-js-sdk/room";
 import RoomListStore, { LISTS_UPDATE_EVENT } from "matrix-react-sdk/src/stores/room-list/RoomListStore";
+import AppBackLeftPanelBtn from "matrix-react-sdk/src/components/views/elements/AppBackLeftPanelBtn";
+import { isInApp } from "matrix-react-sdk/src/utils/env";
 
 interface IProps {
     space: Room;
@@ -382,8 +384,9 @@ const SpaceHierarchy: React.FC<IProps> = ({ space, initialText = "", showRoom, a
         <RovingTabIndexProvider onKeyDown={onKeyDown} handleHomeEnd handleUpDown>
             {({ onKeyDownHandler }) => {
                 return (
-                    <div className="mx_SpaceHierarchy_page">
+                    <div className={`mx_SpaceHierarchy_page ${isInApp ? "inApp" : ""}`}>
                         <div className="mx_SpaceHierarchy_header">
+                            <AppBackLeftPanelBtn />
                             <div className="mx_SpaceHierarchy_title_box">
                                 <div className="mx_SpaceHierarchy_title_icon" />
                                 <p className="mx_SpaceHierarchy_title">首页</p>

--- a/src/matrix-react-sdk/src/components/views/dialogs/ForwardDialog.tsx
+++ b/src/matrix-react-sdk/src/components/views/dialogs/ForwardDialog.tsx
@@ -49,6 +49,7 @@ import DialogButtons from "matrix-react-sdk/src/components/views/elements/Dialog
 import Field, { SelectedUserOrRoomTile } from "matrix-react-sdk/src/components/views/elements/Field";
 import ContextMenu, { ChevronFace } from "matrix-react-sdk/src/components/structures/ContextMenu";
 import RoomAndChannelAvatar from "matrix-react-sdk/src/components/views/avatars/RoomAndChannelAvatar";
+import { isInApp } from "matrix-react-sdk/src/utils/env";
 
 const AVATAR_SIZE = 30;
 
@@ -304,7 +305,7 @@ const ForwardDialog: React.FC<IProps> = ({ matrixClient: cli, event, permalinkCr
     return (
         <BaseDialog
             title={_t("Forward message")}
-            className="mx_ForwardDialog"
+            className={`mx_ForwardDialog ${isInApp ? "inApp" : ""}`}
             onFinished={onFinished}
             fixedWidth={false}
             footer={footer}

--- a/src/matrix-react-sdk/src/components/views/elements/AppBackLeftPanelBtn.tsx
+++ b/src/matrix-react-sdk/src/components/views/elements/AppBackLeftPanelBtn.tsx
@@ -3,7 +3,6 @@ import { useShowLeftPanel } from "matrix-react-sdk/src/hooks/useShowLeftPanel";
 
 const AppBackLeftPanelBtn = () => {
     const [showLeftPanel, setShowLeftPanel] = useShowLeftPanel();
-    console.log("showLeftPanel", showLeftPanel);
     return <>{!showLeftPanel && <div className="mx_RoomViewHeader_back" onClick={() => setShowLeftPanel(true)} />}</>;
 };
 

--- a/src/matrix-react-sdk/src/components/views/elements/AppBackLeftPanelBtn.tsx
+++ b/src/matrix-react-sdk/src/components/views/elements/AppBackLeftPanelBtn.tsx
@@ -1,0 +1,10 @@
+import React, { memo } from "react";
+import { useShowLeftPanel } from "matrix-react-sdk/src/hooks/useShowLeftPanel";
+
+const AppBackLeftPanelBtn = () => {
+    const [showLeftPanel, setShowLeftPanel] = useShowLeftPanel();
+    console.log("showLeftPanel", showLeftPanel);
+    return <>{!showLeftPanel && <div className="mx_RoomViewHeader_back" onClick={() => setShowLeftPanel(true)} />}</>;
+};
+
+export default memo(AppBackLeftPanelBtn);

--- a/src/matrix-react-sdk/src/components/views/elements/ImageView.tsx
+++ b/src/matrix-react-sdk/src/components/views/elements/ImageView.tsx
@@ -38,6 +38,7 @@ import { ViewRoomPayload } from "../../../dispatcher/payloads/ViewRoomPayload";
 import { KeyBindingAction } from "../../../accessibility/KeyboardShortcuts";
 import { getKeyBindingsManager } from "../../../KeyBindingsManager";
 import { presentableTextForFile } from "../../../utils/FileUtils";
+import { isInApp } from "matrix-react-sdk/src/utils/env";
 
 // Max scale to keep gaps around the image
 const MAX_SCALE = 0.95;
@@ -547,8 +548,12 @@ export default class ImageView extends React.Component<IProps, IState> {
                 ref={this.focusLock}
             >
                 <div className="mx_ImageView_panel">
-                    {info}
-                    {title}
+                    {!isInApp && (
+                        <>
+                            {info}
+                            {title}
+                        </>
+                    )}
                     <div className="mx_ImageView_toolbar">
                         {zoomOutButton}
                         {zoomInButton}

--- a/src/matrix-react-sdk/src/components/views/elements/ImageView.tsx
+++ b/src/matrix-react-sdk/src/components/views/elements/ImageView.tsx
@@ -39,6 +39,7 @@ import { KeyBindingAction } from "../../../accessibility/KeyboardShortcuts";
 import { getKeyBindingsManager } from "../../../KeyBindingsManager";
 import { presentableTextForFile } from "../../../utils/FileUtils";
 import { isInApp } from "matrix-react-sdk/src/utils/env";
+import { download } from "matrix-react-sdk/src/utils/download";
 
 // Max scale to keep gaps around the image
 const MAX_SCALE = 0.95;
@@ -319,12 +320,7 @@ export default class ImageView extends React.Component<IProps, IState> {
     };
 
     private onDownloadClick = (): void => {
-        const a = document.createElement("a");
-        a.href = this.props.src;
-        if (this.props.name) a.download = this.props.name;
-        a.target = "_blank";
-        a.rel = "noreferrer noopener";
-        a.click();
+        download(this.props.src, this.props.name);
     };
 
     private onOpenContextMenu = (): void => {

--- a/src/matrix-react-sdk/src/components/views/messages/MImageBody.tsx
+++ b/src/matrix-react-sdk/src/components/views/messages/MImageBody.tsx
@@ -130,7 +130,9 @@ export default class MImageBody extends React.Component<IBodyProps, IState> {
                 };
             }
 
-            Modal.createDialog(ImageView, params, "mx_Dialog_lightbox", undefined, true);
+            Modal.createDialog(ImageView, params, "mx_Dialog_lightbox", undefined, true, {
+                fullScreen: true,
+            });
         }
     };
 

--- a/src/matrix-react-sdk/src/components/views/messages/MImageBody.tsx
+++ b/src/matrix-react-sdk/src/components/views/messages/MImageBody.tsx
@@ -40,6 +40,7 @@ import { presentableTextForFile } from "../../../utils/FileUtils";
 import { createReconnectedListener } from "../../../utils/connection";
 import MediaProcessingError from "./shared/MediaProcessingError";
 import { DecryptError, DownloadError } from "../../../utils/DecryptFile";
+import { getRequestImageSrc } from "matrix-react-sdk/src/components/views/avatars/BaseAvatar";
 
 enum Placeholder {
     NoImage,
@@ -275,8 +276,8 @@ export default class MImageBody extends React.Component<IBodyProps, IState> {
                 return;
             }
         } else {
-            thumbUrl = this.getThumbUrl();
-            contentUrl = this.getContentUrl();
+            thumbUrl = getRequestImageSrc(this.getThumbUrl());
+            contentUrl = getRequestImageSrc(this.getContentUrl());
         }
 
         const content = this.props.mxEvent.getContent<IMediaEventContent>();

--- a/src/matrix-react-sdk/src/components/views/rooms/BasicMessageComposer.tsx
+++ b/src/matrix-react-sdk/src/components/views/rooms/BasicMessageComposer.tsx
@@ -53,6 +53,7 @@ import { linkify } from "../../../linkify-matrix";
 import { SdkContextClass } from "../../../contexts/SDKContext";
 import withRoomPermissions from "matrix-react-sdk/src/hocs/withRoomPermissions";
 import { StateEventType } from "matrix-react-sdk/src/powerLevel";
+import { isInApp } from "matrix-react-sdk/src/utils/env";
 
 // matches emoticons which follow the start of a line or whitespace
 const REGEX_EMOTICON_WHITESPACE = new RegExp("(?:^|\\s)(" + EMOTICON_REGEX.source + ")\\s|:^$");
@@ -736,7 +737,7 @@ class BasicMessageEditor extends React.Component<IProps, IState> {
         this.editorRef.current?.addEventListener("input", this.onInput, true);
         this.editorRef.current?.addEventListener("compositionstart", this.onCompositionStart, true);
         this.editorRef.current?.addEventListener("compositionend", this.onCompositionEnd, true);
-        this.editorRef.current?.focus();
+        !isInApp && this.focus();
     }
 
     private getInitialCaretPosition(): DocumentPosition {

--- a/src/matrix-react-sdk/src/components/views/rooms/RoomHeader.tsx
+++ b/src/matrix-react-sdk/src/components/views/rooms/RoomHeader.tsx
@@ -58,6 +58,7 @@ import RoomCallBanner from "../beacon/RoomCallBanner";
 import RoomAndChannelAvatar from "matrix-react-sdk/src/components/views/avatars/RoomAndChannelAvatar";
 import LayoutStore, { UPDATE_SHOW_LEFT_PANEL } from "matrix-react-sdk/src/stores/LayoutStore";
 import { isInApp } from "matrix-react-sdk/src/utils/env";
+import AppBackLeftPanelBtn from "matrix-react-sdk/src/components/views/elements/AppBackLeftPanelBtn";
 
 interface CallLayoutSelectorProps {
     call: ElementCall;
@@ -428,7 +429,7 @@ export default class RoomHeader extends React.Component<IProps, IState> {
                     className="mx_RoomHeader_wrapper"
                     aria-owns={this.state.rightPanelOpen ? "mx_RightPanel" : undefined}
                 >
-                    {!this.state.showLeftPanel && <div className="mx_RoomHeader_back" onClick={this.onShowLeftPanel} />}
+                    <AppBackLeftPanelBtn />
                     <div className="mx_RoomHeader_name_topic">
                         <div className="mx_RoomHeader_name_box">
                             <div className="mx_RoomHeader_avatar">{roomAvatar}</div>

--- a/src/matrix-react-sdk/src/components/views/spaces/SpaceHomeEntrance.tsx
+++ b/src/matrix-react-sdk/src/components/views/spaces/SpaceHomeEntrance.tsx
@@ -8,6 +8,8 @@ import { ViewRoomPayload } from "matrix-react-sdk/src/dispatcher/payloads/ViewRo
 import { SdkContextClass } from "matrix-react-sdk/src/contexts/SDKContext";
 import { UPDATE_EVENT } from "matrix-react-sdk/src/stores/AsyncStore";
 import { _t } from "matrix-react-sdk/src/languageHandler";
+import { isInApp } from "matrix-react-sdk/src/utils/env";
+import LayoutStore from "matrix-react-sdk/src/stores/LayoutStore";
 
 interface IProps {
     pageType: PageType;
@@ -36,13 +38,16 @@ function SpaceHomeEntrance({ pageType, space }: IProps): JSX.Element {
     const goSpaceHome = () => {
         if (space === MetaSpace.Home) {
             dis.dispatch({ action: Action.ViewHomePage });
-            return;
+        } else {
+            dis.dispatch<ViewRoomPayload>({
+                action: Action.ViewRoom,
+                room_id: space,
+                metricsTrigger: undefined, // other
+            });
         }
-        dis.dispatch<ViewRoomPayload>({
-            action: Action.ViewRoom,
-            room_id: space,
-            metricsTrigger: undefined, // other
-        });
+
+        // 隐藏左侧边栏
+        isInApp && LayoutStore.instance.setShowLeftPanel(false);
     };
 
     return (

--- a/src/matrix-react-sdk/src/customisations/Media.ts
+++ b/src/matrix-react-sdk/src/customisations/Media.ts
@@ -20,6 +20,7 @@ import { Optional } from "matrix-events-sdk";
 
 import { MatrixClientPeg } from "../MatrixClientPeg";
 import { IMediaEventContent, IPreparedMedia, prepEventContentAsMedia } from "./models/IMediaEventContent";
+import { getRequestUrl } from "../../../vector/rewrite-js-sdk/fetch";
 
 // Populate this class with the details of your customisations when copying it.
 
@@ -36,7 +37,10 @@ export class Media {
     private client: MatrixClient;
 
     // Per above, this constructor signature can be whatever is helpful for you.
-    public constructor(private prepared: IPreparedMedia, client?: MatrixClient) {
+    public constructor(
+        private prepared: IPreparedMedia,
+        client?: MatrixClient,
+    ) {
         this.client = client ?? MatrixClientPeg.get();
         if (!this.client) {
             throw new Error("No possible MatrixClient for media resolution. Please provide one or log in.");
@@ -77,7 +81,7 @@ export class Media {
      */
     public get srcHttp(): string | null {
         // eslint-disable-next-line no-restricted-properties
-        return this.client.mxcUrlToHttp(this.srcMxc);
+        return getRequestUrl(this.client.mxcUrlToHttp(this.srcMxc));
     }
 
     /**
@@ -167,7 +171,7 @@ export function mediaFromMxc(mxc?: string, client?: MatrixClient): Media {
 
 export function getHttpUrlFromMxc(url, size = 0): string | null {
     if (!url) return null;
-    if (url.startsWith('mxc://')) {
+    if (url.startsWith("mxc://")) {
         const media = mediaFromMxc(url);
         if (!size || size <= 0) {
             return media.srcHttp;
@@ -180,13 +184,12 @@ export function getHttpUrlFromMxc(url, size = 0): string | null {
 
 export function getSourceHttpUrlFromMxc(url, width, height, resizeMethod?): string | null {
     if (!url) return null;
-    if (url.startsWith('mxc://')) {
+    if (url.startsWith("mxc://")) {
         const media = mediaFromMxc(url);
         if (width !== undefined && height !== undefined) {
             return media.getThumbnailOfSourceHttp(width, height, resizeMethod);
         }
         return media.srcHttp;
-
     }
     return url;
 }

--- a/src/matrix-react-sdk/src/hooks/room/useShowSettingsPanel.ts
+++ b/src/matrix-react-sdk/src/hooks/room/useShowSettingsPanel.ts
@@ -1,9 +1,9 @@
 import { useEffect, useState, useCallback } from "react";
 import LayoutStore, { UPDATE_SETTINGS_SHOW_LEFT_PANEL } from "matrix-react-sdk/src/stores/LayoutStore";
 
-export type SetShowLeftPanel = (show: boolean) => void;
+export type SetShowRoomSettingsLeftPanel = (show: boolean) => void;
 
-export function useShowSettingsLeftPanel() {
+export function useShowSettingsLeftPanel(): [boolean, SetShowRoomSettingsLeftPanel] {
     const [show, setShow] = useState<boolean>(LayoutStore.instance.showSettingsLeftPanel);
 
     useEffect(() => {
@@ -17,7 +17,7 @@ export function useShowSettingsLeftPanel() {
         };
     }, []);
 
-    const setShowLeftPanel: SetShowLeftPanel = useCallback((show) => {
+    const setShowLeftPanel: SetShowRoomSettingsLeftPanel = useCallback((show) => {
         LayoutStore.instance.setShowSettingsLeftPanel(show);
     }, []);
 

--- a/src/matrix-react-sdk/src/hooks/useShowLeftPanel.ts
+++ b/src/matrix-react-sdk/src/hooks/useShowLeftPanel.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState, useCallback } from "react";
+import LayoutStore, { UPDATE_SHOW_LEFT_PANEL } from "matrix-react-sdk/src/stores/LayoutStore";
+
+export type SetShowLeftPanel = (show: boolean) => void;
+
+export function useShowLeftPanel(): [boolean, SetShowLeftPanel] {
+    const [show, setShow] = useState<boolean>(LayoutStore.instance.showLeftPanel);
+
+    useEffect(() => {
+        const updateShowLeftPanel = () => {
+            setShow(LayoutStore.instance.showLeftPanel);
+        };
+
+        LayoutStore.instance.on(UPDATE_SHOW_LEFT_PANEL, updateShowLeftPanel);
+        return () => {
+            LayoutStore.instance.off(UPDATE_SHOW_LEFT_PANEL, updateShowLeftPanel);
+        };
+    }, []);
+
+    const setShowLeftPanel: SetShowLeftPanel = useCallback((show) => {
+        LayoutStore.instance.setShowLeftPanel(show);
+    }, []);
+
+    return [show, setShowLeftPanel];
+}

--- a/src/matrix-react-sdk/src/utils/FileDownloader.ts
+++ b/src/matrix-react-sdk/src/utils/FileDownloader.ts
@@ -47,7 +47,7 @@ function getManagedIframe(): { iframe: HTMLIFrameElement; onLoadPromise: Promise
 
     // @ts-ignore
     // noinspection JSConstantReassignment
-    managedIframe.sandbox = "allow-scripts allow-same-origin allow-downloads allow-downloads-without-user-activation";
+    managedIframe.sandbox = "allow-scripts allow-same-origin allow-downloads";
 
     onLoadPromise = new Promise((resolve) => {
         managedIframe.onload = () => {
@@ -91,6 +91,7 @@ export class FileDownloader {
     public async download({ blob, name, autoDownload = true, opts = DEFAULT_STYLES }: DownloadOptions): Promise<void> {
         const iframe = this.iframe; // get the iframe first just in case we need to await onload
         if (this.onLoadPromise) await this.onLoadPromise;
+        console.log("enter download, postMessage to iframe", blob);
         iframe.contentWindow?.postMessage(
             {
                 ...opts,

--- a/src/matrix-react-sdk/src/utils/download.ts
+++ b/src/matrix-react-sdk/src/utils/download.ts
@@ -1,0 +1,8 @@
+export function download(src: string, name?: string) {
+    const a = document.createElement("a");
+    a.href = src;
+    if (name) a.download = name;
+    a.target = "_blank";
+    a.rel = "noreferrer noopener";
+    a.click();
+}

--- a/src/matrix-react-sdk/src/utils/env.ts
+++ b/src/matrix-react-sdk/src/utils/env.ts
@@ -2,6 +2,7 @@
 enum DevModel {
     Desktop,
     WebSite,
+    App,
 }
 const devModel: DevModel = DevModel.Desktop; // 本地开发模式，默认为客户端模式
 
@@ -24,6 +25,8 @@ export const isProdWebSite = isWebSite && !isDev; // 是否是打包后的web网
 export const isDesktopModelDev = isDev && devModel === DevModel.Desktop; // 本地开发模式是否是客户端模式
 
 export const isWebSiteModelDev = isDev && devModel === DevModel.WebSite; // 本地开发模式是否是web网页端模式
+
+export const isAppModelDev = isDev && devModel === DevModel.App; // 本地开发模式是否是app端模式
 
 export const matrixHostnamePrefix = "matrix.system.service"; // matrix服务域名前缀
 export const ipfsHostnamePrefix = "file.system.service"; // ipfs服务域名前缀

--- a/src/matrix-react-sdk/src/utils/env.ts
+++ b/src/matrix-react-sdk/src/utils/env.ts
@@ -23,7 +23,7 @@ export const isProdWebSite = isWebSite && !isDev; // 是否是打包后的web网
 
 export const isDesktopModelDev = isDev && devModel === DevModel.Desktop; // 本地开发模式是否是客户端模式
 
-export const isWebSiteModelDev = isDev && devModel === DevModel.WebSite; // 本地开发模式是否是wen网页端模式
+export const isWebSiteModelDev = isDev && devModel === DevModel.WebSite; // 本地开发模式是否是web网页端模式
 
 export const matrixHostnamePrefix = "matrix.system.service"; // matrix服务域名前缀
 export const ipfsHostnamePrefix = "file.system.service"; // ipfs服务域名前缀

--- a/src/vector/rewrite-js-sdk/fetch.ts
+++ b/src/vector/rewrite-js-sdk/fetch.ts
@@ -5,6 +5,7 @@ import {
     matrixHostnamePrefix,
     ipfsHostnamePrefix,
     isDesktopModelDev,
+    isAppModelDev,
 } from "matrix-react-sdk/src/utils/env";
 
 // 拦截fetch请求
@@ -68,7 +69,7 @@ export function getRequestUrlInPlatform(resource: string | URL, needProxiedOrigi
             searchParams.set("real-origin", needProxiedOrigin);
             url.set("query", searchParams.toString());
         }
-        return url.toString().replace(needProxiedOrigin, "");
+        return url.toString().replace(needProxiedOrigin, isAppModelDev ? "/app" : "");
     }
 
     // web网页端做请求拦截（本地开发 & 官网chat）


### PR DESCRIPTION
1. 本地开发新增App端模式
2. 解决web端和app端发送的图片不展示的bug
3. app端图片预览弹窗样式调整
4. 解决app端图片和文件不能下载的bug
5. app端频道主面板 & 消息列面板消息输入框默认不聚焦，不拉起键盘
6. app端 home页和社区新增首页入口，并在首页添加返回左侧边栏按钮